### PR TITLE
initial attempt at domain-separation for PRF_msg

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -499,11 +499,12 @@ def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
 The tweaked hash function `PRF_msg_sf`.
 
 <!-- DOC START PRF_msg_sf -->
-Uses HMAC-SHA256 to hash `sk_prf`, an `ADRS`, and an arbitrary-length message `M`. This function
+Uses HMAC-SHA256 to hash `sk_prf`, the `pk_seed`, an `ADRS`, and an arbitrary-length message `M`. This function
 will be used to derive a _randomizer_ (salt) for the given message in the stateful path.
 
 - Inputs:
   - `sk_prf`: a 16-byte secret.
+  - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
   - `M`: an arbitrary-length bytestring (TODO).
 - Output:
@@ -512,8 +513,8 @@ will be used to derive a _randomizer_ (salt) for the given message in the statef
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def PRF_msg_sf(sk_prf: bytes, ADRS: bytearray, M: bytes) -> bytes:
-  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), msg=ADRS[:9] + M)[:16]
+def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> bytes:
+  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), msg=pk_seed + ADRS[:9] + M)[:16]
 ```
 <!-- DOC END PRF_msg_sf -->
 

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -465,13 +465,14 @@ Unlike `H_msg_sl`, this function is a SHRINCS-specific construction and is **not
 - The WOTS+C leaf position given by `ADRS` is bound into both the inner and outer hash inputs. This domain-separates the stateful digest by the leaf used to sign it.
 
 
-### `PRF_msg(...)`
+### `PRF_msg_sl(...)`
 
-The tweaked hash function `PRF_msg`.
+The tweaked hash function `PRF_msg_sl`.
 
-<!-- DOC START PRF_msg -->
+<!-- DOC START PRF_msg_sl -->
 Uses HMAC-SHA256 to hash `sk_prf`, randomness `opt_rand`, and an arbitrary-length message `M`.
-This function will be used to derive a _randomizer_ (salt) for the given message.
+This function will be used to derive a _randomizer_ (salt) for the given message in
+the stateless path.
 
 - Inputs:
   - `sk_prf`: a 16-byte secret.
@@ -480,19 +481,45 @@ This function will be used to derive a _randomizer_ (salt) for the given message
 - Output:
   - A 16-byte hash.
 
-This function is used in both stateful and stateless paths, but only by the signing algorithm.
+This function is only used in the stateless path, and only by the signer.
 
-In the stateless path, `opt_rand` is set to either `pk_seed` (giving the "deterministic variant"
-of SLH-DSA[^slhdsa]), or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA,
-resistant to side-channel attacks).
-
-In the stateful path, `opt_rand` is set to `ADRS[0:9] + zeros(7)`.
+`opt_rand` is set to either `pk_seed` (giving the "deterministic variant" of SLH-DSA[^slhdsa]),
+or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA, resistant to
+side-channel attacks).
 
 ```py
-def PRF_msg(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
+def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   return hmac_sha256(key=sk_prf, msg=opt_rand + M)[:16]
 ```
-<!-- DOC END PRF_msg -->
+<!-- DOC END PRF_msg_sl -->
+
+
+### `PRF_msg_sf(...)`
+
+The tweaked hash function `PRF_msg_sf`.
+
+<!-- DOC START PRF_msg_sf -->
+Uses HMAC-SHA256 to hash `sk_prf`, an `ADRS`, and an arbitrary-length message `M`. This function
+will be used to derive a _randomizer_ (salt) for the given message in the stateful path.
+
+- Inputs:
+  - `sk_prf`: a 16-byte secret.
+  - `ADRS`: a 22-byte address.
+  - `M`: an arbitrary-length bytestring (TODO).
+- Output:
+  - A 16-byte hash.
+
+This function is only used in the stateful path, and only by the signer.
+
+```py
+def PRF_msg_sf(sk_prf: bytes, ADRS: bytearray, M: bytes) -> bytes:
+  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), msg=ADRS[:9] + M)[:16]
+```
+<!-- DOC END PRF_msg_sf -->
+
+The `sk_prf` is padded with `0xFF` up until it is 64 bytes long. This ensures domain separation between stateful and stateless paths.
+
+We only use the first 9 bytes of `ADRS`, because these bytes encode the position of the WOTS+C leaf in the FXMSS tree.
 
 
 ### Implementation Notes

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -482,9 +482,11 @@ This function will be used to derive a _randomizer_ (salt) for the given message
 
 This function is used in both stateful and stateless paths, but only by the signing algorithm.
 
-If deterministic signing is required and an RNG is not available, `opt_rand` will be set to `pk_seed`.
+In the stateless path, `opt_rand` is set to either `pk_seed` (giving the "deterministic variant"
+of SLH-DSA[^slhdsa]), or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA,
+resistant to side-channel attacks).
 
-TODO: domain separate between stateful/stateless.
+In the stateful path, `opt_rand` is set to `ADRS[0:9] + zeros(7)`.
 
 ```py
 def PRF_msg(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -252,9 +252,11 @@ def PRF_msg(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
 
   This function is used in both stateful and stateless paths, but only by the signing algorithm.
 
-  If deterministic signing is required and an RNG is not available, `opt_rand` will be set to `pk_seed`.
+  In the stateless path, `opt_rand` is set to either `pk_seed` (giving the "deterministic variant"
+  of SLH-DSA[^slhdsa]), or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA,
+  resistant to side-channel attacks).
 
-  TODO: domain separate between stateful/stateless.
+  In the stateful path, `opt_rand` is set to `ADRS[0:9] + zeros(7)`.
   """
   return hmac_sha256(key=sk_prf, msg=opt_rand + M)[:16]
 

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -238,10 +238,11 @@ def H_msg_sf(R: bytes, pk_seed: bytes, root: bytes, ADRS: bytearray, M: bytes) -
   """
   return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + root + ADRS[:9] + M))
 
-def PRF_msg(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
+def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   """
   Uses HMAC-SHA256 to hash `sk_prf`, randomness `opt_rand`, and an arbitrary-length message `M`.
-  This function will be used to derive a _randomizer_ (salt) for the given message.
+  This function will be used to derive a _randomizer_ (salt) for the given message in
+  the stateless path.
 
   - Inputs:
     - `sk_prf`: a 16-byte secret.
@@ -250,15 +251,29 @@ def PRF_msg(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   - Output:
     - A 16-byte hash.
 
-  This function is used in both stateful and stateless paths, but only by the signing algorithm.
+  This function is only used in the stateless path, and only by the signer.
 
-  In the stateless path, `opt_rand` is set to either `pk_seed` (giving the "deterministic variant"
-  of SLH-DSA[^slhdsa]), or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA,
-  resistant to side-channel attacks).
-
-  In the stateful path, `opt_rand` is set to `ADRS[0:9] + zeros(7)`.
+  `opt_rand` is set to either `pk_seed` (giving the "deterministic variant" of SLH-DSA[^slhdsa]),
+  or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA, resistant to
+  side-channel attacks).
   """
   return hmac_sha256(key=sk_prf, msg=opt_rand + M)[:16]
+
+def PRF_msg_sf(sk_prf: bytes, ADRS: bytearray, M: bytes) -> bytes:
+  """
+  Uses HMAC-SHA256 to hash `sk_prf`, an `ADRS`, and an arbitrary-length message `M`. This function
+  will be used to derive a _randomizer_ (salt) for the given message in the stateful path.
+
+  - Inputs:
+    - `sk_prf`: a 16-byte secret.
+    - `ADRS`: a 22-byte address.
+    - `M`: an arbitrary-length bytestring (TODO).
+  - Output:
+    - A 16-byte hash.
+
+  This function is only used in the stateful path, and only by the signer.
+  """
+  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), msg=ADRS[:9] + M)[:16]
 
 
 #  Winternitz algorithms

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -259,13 +259,14 @@ def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   """
   return hmac_sha256(key=sk_prf, msg=opt_rand + M)[:16]
 
-def PRF_msg_sf(sk_prf: bytes, ADRS: bytearray, M: bytes) -> bytes:
+def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> bytes:
   """
-  Uses HMAC-SHA256 to hash `sk_prf`, an `ADRS`, and an arbitrary-length message `M`. This function
+  Uses HMAC-SHA256 to hash `sk_prf`, the `pk_seed`, an `ADRS`, and an arbitrary-length message `M`. This function
   will be used to derive a _randomizer_ (salt) for the given message in the stateful path.
 
   - Inputs:
     - `sk_prf`: a 16-byte secret.
+    - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
     - `M`: an arbitrary-length bytestring (TODO).
   - Output:
@@ -273,7 +274,7 @@ def PRF_msg_sf(sk_prf: bytes, ADRS: bytearray, M: bytes) -> bytes:
 
   This function is only used in the stateful path, and only by the signer.
   """
-  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), msg=ADRS[:9] + M)[:16]
+  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), msg=pk_seed + ADRS[:9] + M)[:16]
 
 
 #  Winternitz algorithms


### PR DESCRIPTION
This implements @error0024's comment:

> Maybe for the domain separation we can fix the opt_rand for both cases. For the stateless part the pk_seed and for the stateful we can use leaf index? RFC 8391 specifies the randomness generation as r = PRF(SK_PRF,idx_sig, 32). 16 bytes will be sufficient for that.

