### PR TITLE
Review: verifier robustness, preconditions, docstring + spec/tooling cleanup 

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -126,11 +126,13 @@ We make use of the following utility helper functions in specifying SHRINCS.
 - `range(start, end)`: returns the ascending sequence of all integers `i` such that `start <= i < end`.
 - `concat(array)`: concatenates an array of byte strings.
 
+Unless stated otherwise, all integers are serialized to and parsed from bytes as fixed-width, big-endian (network byte order) values, where the width is the size of the byte field the integer occupies.
+
 
 ### `base_2b(...)`
 
 <!-- DOC START base_2b -->
-Decomposes a byte string `x` into `outlen` groups of `b` bits which are each
+Decomposes the bytes `x` into `outlen` groups of `b` bits which are each
 parsed as an integer in the range `[0, 2**b)`. The leading `outlen * b` bits
 of `x` are parsed, and so `x` must have accordingly sufficient length.
 
@@ -263,10 +265,11 @@ In one case, we use HMAC-SHA256[^hmac], which we invoke as the function `hmac_sh
 
 <!-- DOC START hmac_sha256 -->
 ```py
-def hmac_sha256(key: bytes, msg: bytes) -> bytes:
+def hmac_sha256(key: bytes, message: bytes) -> bytes:
   assert len(key) <= 64
+  assert len(message) <= 2**61 - 1 - 64
   padded_key = key + zeros(64 - len(key))
-  inner = sha256(xor(padded_key, repeat(0x36, 64)) + msg)
+  inner = sha256(xor(padded_key, repeat(0x36, 64)) + message)
   return sha256(xor(padded_key, repeat(0x5C, 64)) + inner)
 ```
 <!-- DOC END hmac_sha256 -->
@@ -281,21 +284,23 @@ The following sections describe tweakable hash functions to fill different roles
 The tweakable hash function `T_sl`.
 
 <!-- DOC START T_sl -->
-Hashes an input `M_l`, which is a sequence of `WOTS_TW_CHAIN_COUNT` hashes, each 16 bytes long,
-concatenated together. This function will be used to compress Winternitz chain tips to a single
-hash in SLH-DSA.
+The `T_sl` tweaked hash function. Compresses `WOTS_TW_CHAIN_COUNT` Winternitz chain tips into a
+single 16-byte hash.
 
 - Inputs:
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-  - `M_l`: an array of `WOTS_TW_CHAIN_COUNT * 16` bytes.
+  - `M_l`: a `WOTS_TW_CHAIN_COUNT * 16`-byte concatenation of chain tips.
 - Output:
-  - A 16-byte hash.
+  - a 16-byte hash.
 
-This function is only used in the stateless path.
+This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
 def T_sl(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_l) == WOTS_TW_CHAIN_COUNT * 16
   return sha256(pk_seed + zeros(48) + ADRS + M_l)[:16]
 ```
 <!-- DOC END T_sl -->
@@ -306,21 +311,23 @@ def T_sl(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
 The tweakable hash function `T_sf`.
 
 <!-- DOC START T_sf -->
-Hashes an input `M_l`, which is a sequence of `WOTS_C_CHAIN_COUNT` hashes, each 16 bytes long,
-concatenated together. This function will be used to compress Winternitz chain tips to a single
-hash in FXMSS.
+The `T_sf` tweaked hash function. Compresses `WOTS_C_CHAIN_COUNT` Winternitz chain tips into a
+single 16-byte hash.
 
 - Inputs:
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-  - `M_l`: an array of `WOTS_C_CHAIN_COUNT * 16` bytes.
+  - `M_l`: a `WOTS_C_CHAIN_COUNT * 16`-byte concatenation of chain tips.
 - Output:
-  - A 16-byte hash.
+  - a 16-byte hash.
 
-This function is only used in the stateful path.
+This function is only used in the stateful path, and by both the signer and the verifier.
 
 ```py
 def T_sf(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_l) == WOTS_C_CHAIN_COUNT * 16
   return sha256(pk_seed + zeros(48) + ADRS + M_l)[:16]
 ```
 <!-- DOC END T_sf -->
@@ -331,21 +338,23 @@ def T_sf(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
 The tweakable hash function `T_k`.
 
 <!-- DOC START T_k -->
-Hashes an input `M_k`, which is a sequence of `SPHX_FORS_COUNT` hashes, each 16 bytes long,
-concatenated together. This function will be used to compress FORS tree roots to a single
-hash in the stateless path.
+The `T_k` tweaked hash function. Compresses `SPHX_FORS_COUNT` FORS tree roots into a single
+16-byte hash.
 
 - Inputs:
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-  - `M_k`: an array of `SPHX_FORS_COUNT * 16` bytes.
+  - `M_k`: a `SPHX_FORS_COUNT * 16`-byte concatenation of FORS tree roots.
 - Output:
-  - A 16-byte hash.
+  - a 16-byte hash.
 
-This function is only used in the stateless path.
+This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
 def T_k(pk_seed: bytes, ADRS: bytearray, M_k: bytes) -> bytes:
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_k) == SPHX_FORS_COUNT * 16
   return sha256(pk_seed + zeros(48) + ADRS + M_k)[:16]
 ```
 <!-- DOC END T_k -->
@@ -356,20 +365,23 @@ def T_k(pk_seed: bytes, ADRS: bytearray, M_k: bytes) -> bytes:
 The tweakable hash function `F`.
 
 <!-- DOC START F -->
-Hashes an input `M_1`, which is a single 16-byte hash. This function will be used to generate
-and iterate Winternitz hash chains and to hash FORS leaves.
+The `F` tweaked hash function. Hashes a single 16-byte input, to generate and iterate Winternitz
+hash chains and to hash FORS leaves.
 
 - Inputs:
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
   - `M_1`: a 16-byte hash.
 - Output:
-  - A 16-byte hash.
+  - a 16-byte hash.
 
-This function is used in both stateful and stateless paths.
+This function is used in both stateful and stateless paths, and by both the signer and the verifier.
 
 ```py
 def F(pk_seed: bytes, ADRS: bytearray, M_1: bytes) -> bytes:
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_1) == 16
   return sha256(pk_seed + zeros(48) + ADRS + M_1)[:16]
 ```
 <!-- DOC END F -->
@@ -380,20 +392,23 @@ def F(pk_seed: bytes, ADRS: bytearray, M_1: bytes) -> bytes:
 The tweakable hash function `H`.
 
 <!-- DOC START H -->
-Hashes an input `M_2`, which is a pair of 16-byte hashes, concatenated together. This function
-will be used to combine pairs of merkle nodes, to construct merkle trees in XMSS and FORS.
+The `H` tweaked hash function. Combines a pair of 16-byte Merkle child nodes into their 16-byte
+parent, building the Merkle trees in XMSS and FORS.
 
 - Inputs:
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-  - `M_2`: an array of 32 bytes.
+  - `M_2`: a 32-byte concatenation of two child node hashes.
 - Output:
-  - A 16-byte hash.
+  - a 16-byte hash.
 
-This function is used in both stateful and stateless paths.
+This function is used in both stateful and stateless paths, and by both the signer and the verifier.
 
 ```py
 def H(pk_seed: bytes, ADRS: bytearray, M_2: bytes) -> bytes:
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_2) == 32
   return sha256(pk_seed + zeros(48) + ADRS + M_2)[:16]
 ```
 <!-- DOC END H -->
@@ -404,24 +419,25 @@ def H(pk_seed: bytes, ADRS: bytearray, M_2: bytes) -> bytes:
 The tweakable hash function `H_grind`.
 
 <!-- DOC START H_grind -->
-Hashes a 32-byte message `digest` and a grinding `counter`. This function will be used to
-map `digest` into a constant-sum message space for WOTS+C. Also takes in `pk_seed` and
-a WOTS+C leaf `ADRS`.
-
+The `H_grind` tweaked hash function. Maps a 32-byte `digest` and grinding `counter` into the
+constant-sum message space for WOTS+C.
 
 - Inputs:
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-  - `digest`: an array of 32 bytes.
+  - `digest`: a 32-byte digest.
   - `counter`: a 16-bit unsigned integer.
 - Output:
-  - A 16-byte hash.
+  - a 16-byte hash.
 
-This function is only used in the stateful path.
+This function is only used in the stateful path, and by both the signer and the verifier.
 
 ```py
 def H_grind(pk_seed: bytes, ADRS: bytearray, digest: bytes, counter: int) -> bytes:
-  assert counter <= 0xFFFF
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(digest) == 32
+  assert 0 <= counter < 2**16
   return sha256(pk_seed + zeros(48) + ADRS[:10] + digest + zeros(4) + counter.to_bytes(2))[:16]
 ```
 <!-- DOC END H_grind -->
@@ -436,20 +452,23 @@ Notice we only use the first 10 bytes of `ADRS`. This ensures the entire hash in
 The tweakable hash function `PRF`.
 
 <!-- DOC START PRF -->
-Hashes `sk_seed` with an `ADRS` to derive secret preimage values needed for signing and key
-generation.
+The `PRF` tweaked hash function. Derives a secret 16-byte preimage from `sk_seed`, for signing
+and key generation.
 
 - Inputs:
   - `pk_seed`: a 16-byte salt.
   - `sk_seed`: a 16-byte secret.
   - `ADRS`: a 22-byte address.
 - Output:
-  - A 16-byte hash.
+  - a 16-byte hash.
 
-This function is used in both stateful and stateless paths, but only by the signing algorithm.
+This function is used in both stateful and stateless paths, but only by the signer.
 
 ```py
 def PRF(pk_seed: bytes, sk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(pk_seed) == 16
+  assert len(sk_seed) == 16
+  assert len(ADRS) == 22
   return sha256(pk_seed + zeros(48) + ADRS + sk_seed)[:16]
 ```
 <!-- DOC END PRF -->
@@ -462,23 +481,26 @@ Note the order of the arguments passed to `PRF` is _not_ the same order in which
 The tweakable hash function `H_msg_sl`.
 
 <!-- DOC START H_msg_sl -->
-Hashes a _randomizer_ `R`, the `pk_seed`, a merkle root `root`, and an arbitrary-length message
-bytestring `M`. It will be used to produce a digest for signing in the stateless path.
+The `H_msg_sl` message hash function. Produces the 32-byte signing digest for the stateless path.
 
 - Inputs:
   - `R`: a 16-byte randomizer.
   - `pk_seed`: a 16-byte salt.
   - `root`: a 16-byte hash.
-  - `M`: an arbitrary-length bytestring (TODO).
+  - `M`: a message of at most `2**61 - 1 - 48` bytes.
 - Output:
-  - A 32-byte hash.
+  - a 32-byte hash.
 
-This function is only used in the stateless path.
+This function is only used in the stateless path, and by both the signer and the verifier.
 
 Note that `pk_seed` is not padded in this tweakable hash function.
 
 ```py
 def H_msg_sl(R: bytes, pk_seed: bytes, root: bytes, M: bytes) -> bytes:
+  assert len(R) == 16
+  assert len(pk_seed) == 16
+  assert len(root) == 16
+  assert len(M) <= 2**61 - 1 - 48
   return sha256(R + pk_seed + sha256(R + pk_seed + root + M) + zeros(4))
 ```
 <!-- DOC END H_msg_sl -->
@@ -491,27 +513,28 @@ The 4-byte zero-padding at the end of the outer hash input ensures `H_msg_sl` sa
 The tweakable hash function `H_msg_sf`.
 
 <!-- DOC START H_msg_sf -->
-Hashes a _randomizer_ `R`, the `pk_seed`, a WOTS+C leaf `ADRS`, a merkle root `root`,
-and an arbitrary-length message bytestring `M`. It will be used to produce a digest for
-signing in the stateful path.
-
-TODO: can `ADRS[:9]` be used only once?
+The `H_msg_sf` message hash function. Produces the 32-byte signing digest for the stateful path.
 
 - Inputs:
   - `R`: a 16-byte randomizer.
   - `pk_seed`: a 16-byte salt.
   - `root`: a 16-byte hash.
   - `ADRS`: a 22-byte address.
-  - `M`: an arbitrary-length bytestring (TODO).
+  - `M`: a message of at most `2**61 - 1 - 57` bytes.
 - Output:
-  - A 32-byte hash.
+  - a 32-byte hash.
 
-This function is only used in the stateful path.
+This function is only used in the stateful path, and by both the signer and the verifier.
 
 Note that `pk_seed` is not padded in this tweakable hash function.
 
 ```py
 def H_msg_sf(R: bytes, pk_seed: bytes, root: bytes, ADRS: bytearray, M: bytes) -> bytes:
+  assert len(R) == 16
+  assert len(pk_seed) == 16
+  assert len(root) == 16
+  assert len(ADRS) == 22
+  assert len(M) <= 2**61 - 1 - 57
   return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + root + ADRS[:9] + M))
 ```
 <!-- DOC END H_msg_sf -->
@@ -529,16 +552,15 @@ Unlike `H_msg_sl`, this function is a SHRINCS-specific construction and is **not
 The tweakable hash function `PRF_msg_sl`.
 
 <!-- DOC START PRF_msg_sl -->
-Uses HMAC-SHA256 to hash `sk_prf`, randomness `opt_rand`, and an arbitrary-length message `M`.
-This function will be used to derive a _randomizer_ (salt) for the given message in
-the stateless path.
+The `PRF_msg_sl` function. Derives the per-message randomizer (salt) for the stateless path via
+HMAC-SHA256.
 
 - Inputs:
   - `sk_prf`: a 16-byte secret.
   - `opt_rand`: a 16-byte salt.
-  - `M`: an arbitrary-length bytestring (TODO).
+  - `M`: a message of at most `2**61 - 1 - 80` bytes.
 - Output:
-  - A 16-byte hash.
+  - a 16-byte hash.
 
 This function is only used in the stateless path, and only by the signer.
 
@@ -548,7 +570,10 @@ resistance to side-channel attacks).
 
 ```py
 def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
-  return hmac_sha256(key=sk_prf, msg=opt_rand + M)[:16]
+  assert len(sk_prf) == 16
+  assert len(opt_rand) == 16
+  assert len(M) <= 2**61 - 1 - 80
+  return hmac_sha256(key=sk_prf, message=opt_rand + M)[:16]
 ```
 <!-- DOC END PRF_msg_sl -->
 
@@ -558,22 +583,26 @@ def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
 The tweakable hash function `PRF_msg_sf`.
 
 <!-- DOC START PRF_msg_sf -->
-Uses HMAC-SHA256 to hash `sk_prf`, the `pk_seed`, an `ADRS`, and an arbitrary-length message `M`. This function
-will be used to derive a _randomizer_ (salt) for the given message in the stateful path.
+The `PRF_msg_sf` function. Derives the per-message randomizer (salt) for the stateful path via
+HMAC-SHA256.
 
 - Inputs:
   - `sk_prf`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-  - `M`: an arbitrary-length bytestring (TODO).
+  - `M`: a message of at most `2**61 - 1 - 89` bytes.
 - Output:
-  - A 16-byte hash.
+  - a 16-byte hash.
 
 This function is only used in the stateful path, and only by the signer.
 
 ```py
 def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> bytes:
-  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), msg=pk_seed + ADRS[:9] + M)[:16]
+  assert len(sk_prf) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M) <= 2**61 - 1 - 89
+  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), message=pk_seed + ADRS[:9] + M)[:16]
 ```
 <!-- DOC END PRF_msg_sf -->
 
@@ -632,25 +661,29 @@ Both WOTS schemes make use of the following common hash-chaining algorithm.
 ### `wots_chain_iter(...)`
 
 <!-- DOC START wots_chain_iter -->
-The WOTS hash chain iteration function. Takes in a 16-byte hash `node` at a given `start` index
-in a hash chain. This method iterates the hash chain by `steps` iterations, returning the hash
-chain node at index `start+steps`. The `ADRS` must be prefilled to ensure the hashes are properly
-tweaked.
+The WOTS hash chain iteration function. Iterates the hash chain from index `start` by `steps`
+steps, returning the node at index `start + steps`. The `ADRS` must be prefilled so the hashes
+are correctly tweaked.
 
 - Inputs:
   - `node`: a 16-byte hash.
-  - `start`: an unsigned integer indicating the index of `node` in the hash chain.
-  - `steps`: an unsigned integer indicating how many steps to take up the hash chain.
+  - `start`: a 32-bit unsigned integer, the index of `node` in its hash chain.
+  - `steps`: a 32-bit unsigned integer, the number of steps to take up the chain; `start + steps` must not exceed `2**32`.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
-  - A 16-byte hash at index `start + steps`.
+  - a 16-byte hash at index `start + steps`.
 
-This function is used very heavily by both stateful and stateless paths and is the core target
-for optimization and parallelization.
+This function is used in both stateful and stateless paths, and by both the signer and the verifier.
 
 ```py
 def wots_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(node) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= start
+  assert 0 <= steps
+  assert start + steps <= 2 ** 32
   for j in range(start, start+steps):
     ADRS[18:22] = j.to_bytes(4)
     node = F(pk_seed, ADRS, node)
@@ -683,18 +716,22 @@ This checksum is then converted into `WOTS_TW_CHAIN_COUNT2` integers of `WOTS_TW
 ### `wots_tw_message_to_indexes(...)`
 
 <!-- DOC START wots_tw_message_to_indexes -->
-The WOTS-TW message map function. Converts a 16-byte `message` to a checksummed array
-of `WOTS_TW_CHAIN_COUNT` WOTS hash chain indexes in the range `[0, 2**WOTS_TW_CHAIN_BITS)`.
+The WOTS-TW message map function. Converts a 16-byte `message` into a checksummed array of
+`WOTS_TW_CHAIN_COUNT` chain indexes in `[0, 2**WOTS_TW_CHAIN_BITS)`.
 
 - Inputs:
-  - `message`: a 16-byte hash
+  - `message`: a 16-byte hash.
 - Output:
-  - An checksummed array of `WOTS_TW_CHAIN_BITS`-bit integers of length `WOTS_TW_CHAIN_COUNT`.
+  - a checksummed array of `WOTS_TW_CHAIN_COUNT` `WOTS_TW_CHAIN_BITS`-bit unsigned integers.
+
+This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
 def wots_tw_message_to_indexes(message: bytes) -> list[int]:
+  assert len(message) == 16
   msg_indexes = base_2b(message, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT1)
   checksum = WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)
+  assert 0 <= checksum <= WOTS_TW_CHECKSUM_MAX
 
   checksum_indexes = [0] * WOTS_TW_CHAIN_COUNT2
   for i in range(WOTS_TW_CHAIN_COUNT2):
@@ -711,11 +748,12 @@ more complex FIPS-205 algorithm.
 
 ```py
 def wots_tw_message_to_indexes_alt(message: bytes) -> list[int]:
-  SPHX_WOTS_CHECKSUM_SHIFT = (8 - (WOTS_TW_CHAIN_BITS * WOTS_TW_CHAIN_COUNT2) % 8) % 8
-  SPHX_WOTS_CHECKSUM_BYTE_LEN = ceil(WOTS_TW_CHAIN_COUNT2 * WOTS_TW_CHAIN_BITS / 8)
+  assert len(message) == 16
+  checksum_shift = (8 - (WOTS_TW_CHAIN_BITS * WOTS_TW_CHAIN_COUNT2) % 8) % 8
+  checksum_byte_len = ceil(WOTS_TW_CHAIN_COUNT2 * WOTS_TW_CHAIN_BITS / 8)
   msg_indexes = base_2b(message, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT1)
-  checksum = (WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)) << SPHX_WOTS_CHECKSUM_SHIFT
-  checksum_bytes = checksum.to_bytes(SPHX_WOTS_CHECKSUM_BYTE_LEN)
+  checksum = (WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)) << checksum_shift
+  checksum_bytes = checksum.to_bytes(checksum_byte_len)
   checksum_indexes = base_2b(checksum_bytes, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT2)
   return msg_indexes + checksum_indexes
 ```
@@ -761,20 +799,23 @@ After appending the checksum, the final checksummed index sequence should look l
 ### `wots_tw_pubkey_gen(...)`
 
 <!-- DOC START wots_tw_pubkey_gen -->
-The WOTS-TW public key generation function. Takes in the secret `sk_seed`, the `pk_seed`,
-and an `ADRS`. The `ADRS` should be prefilled with the location of the WOTS keypair being used.
+The WOTS-TW public key generation function. Computes the 16-byte WOTS-TW public key at the
+keypair location prefilled in `ADRS`.
 
 - Inputs:
   - `sk_seed`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
-  - A 16-byte hash representing the WOTS-TW public key.
+  - a 16-byte hash representing the WOTS-TW public key.
 
-This algorithm is used only by the signer.
+This function is only used in the stateless path, and only by the signer.
 
 ```py
 def wots_tw_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   wots_pk = [b''] * WOTS_TW_CHAIN_COUNT
   for i in range(WOTS_TW_CHAIN_COUNT):
     ADRS[9] = SL_WOTS_TW_PRF
@@ -795,8 +836,8 @@ def wots_tw_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes
 ### `wots_tw_sign(...)`
 
 <!-- DOC START wots_tw_sign -->
-The WOTS-TW signing function. Takes in a 16-byte `message`, the `sk_seed` and `pk_seed`,
-and an `ADRS`. The `ADRS` should be prefilled with the location of the WOTS keypair being used.
+The WOTS-TW signing function. Produces a WOTS-TW signature on a 16-byte `message`, at the keypair
+location prefilled in `ADRS`.
 
 - Inputs:
   - `message`: a 16-byte message to sign.
@@ -804,12 +845,16 @@ and an `ADRS`. The `ADRS` should be prefilled with the location of the WOTS keyp
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
-  - A WOTS signature composed of `WOTS_TW_CHAIN_COUNT * 16` bytes.
+  - a `WOTS_TW_CHAIN_COUNT * 16`-byte signature.
 
-This algorithm is used only by the signer.
+This function is only used in the stateless path, and only by the signer.
 
 ```py
 def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(message) == 16
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   indexes = wots_tw_message_to_indexes(message)
   signature = [b''] * WOTS_TW_CHAIN_COUNT
   for i in range(WOTS_TW_CHAIN_COUNT):
@@ -827,22 +872,25 @@ def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray
 ### `wots_tw_pubkey_from_sig(...)`
 
 <!-- DOC START wots_tw_pubkey_from_sig -->
-The WOTS-TW verification procedure. Recovers a WOTS-TW public key from a `signature` on a given
-16-byte `message`. Takes in the `pk_seed`. The `ADRS` should be prefilled with the location of
-the WOTS keypair being used.
+The WOTS-TW verification function. Recovers a WOTS-TW public key from a `signature` on a 16-byte
+`message`.
 
 - Inputs:
-  - `signature`: a string of `WOTS_TW_CHAIN_COUNT * 16` bytes.
+  - `signature`: a `WOTS_TW_CHAIN_COUNT * 16`-byte signature.
   - `message`: a 16-byte message.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
-  - A 16-byte hash representing the WOTS-TW public key.
+  - a 16-byte hash representing the WOTS-TW public key.
 
-This algorithm is used by both signers and verifiers.
+This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
 def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(signature) == WOTS_TW_CHAIN_COUNT * 16
+  assert len(message) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   indexes = wots_tw_message_to_indexes(message)
   wots_pk = [b''] * WOTS_TW_CHAIN_COUNT
   ADRS[9] = SL_WOTS_TW_HASH
@@ -879,24 +927,24 @@ Eventually the signer finds a counter which maps the message to a set of indexes
 ### `wots_c_grind_to_constant_sum(...)`
 
 <!-- DOC START wots_c_grind_to_constant_sum -->
-The WOTS+C grinding function. Takes in a `message_digest`, the `pk_seed`, and an `ADRS`, and
-grinds - up to a maximum of 2<sup>16</sup> attempts - until we find a counter that maps to a
-constant sum index-set. Returns the lowest valid integer counter and the corresponding array
-of constant-sum hash chain indexes. The `ADRS` should be prefilled with the location of the
-WOTS+C key which will be used to sign the resulting indexes.
+The WOTS+C grinding function. Grinds up to 2^16 counters until one maps `message_digest` to a
+constant-sum index set, returning the lowest such counter and its index set.
 
 - Inputs:
   - `pk_seed`: a 16-byte salt.
   - `message_digest`: a 32-byte intermediate message digest (from `H_msg_sf`).
   - `ADRS`: a 22-byte address.
-- Outputs:
-  - The smallest possible valid counter.
-  - The corresponding constant-sum set of hash chain indexes.
+- Output:
+  - a tuple `(counter, indexes)`: the smallest valid 16-bit `counter` and the corresponding
+    constant-sum set of hash chain indexes (of length `WOTS_C_CHAIN_COUNT`).
 
-This algorithm is used only by the signer.
+This function is only used in the stateful path, and only by the signer.
 
 ```py
 def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: bytearray) -> tuple[int, list[int]]:
+  assert len(pk_seed) == 16
+  assert len(message_digest) == 32
+  assert len(ADRS) == 22
   ADRS[9] = SF_WOTS_C_GRIND
   for i in range(2**16):
     hashed = H_grind(pk_seed, ADRS, message_digest, i)
@@ -914,23 +962,25 @@ We max out at 2<sup>16</sup> grinding attempts because the counter is serialized
 ### `wots_c_map_digest(...)`
 
 <!-- DOC START wots_c_map_digest -->
-The WOTS+C digest validation function. Takes in a `message_digest`, the `pk_seed`, an `ADRS`,
-and a `counter` parsed from a WOTS+C signature. This evaluates the grinding counter and attempts
-to map the digest to a constant sum set of hash chain indexes. If the `counter` is valid, this
-function returns the constant sum index-set. Otherwise, it returns null.
+The WOTS+C digest validation function. Evaluates a signature's grinding `counter` and returns the
+constant-sum index set it yields, or null if the counter is invalid.
 
 - Inputs:
   - `pk_seed`: a 16-byte salt.
   - `message_digest`: a 32-byte intermediate message digest (from `H_msg_sf`).
   - `ADRS`: a 22-byte address.
-  - `counter`: an unsigned integer.
+  - `counter`: a 16-bit unsigned integer.
 - Output:
-  - A constant-sum set of hash chain indexes, or null.
+  - a constant-sum set of hash chain indexes (of length `WOTS_C_CHAIN_COUNT`), or null.
 
-This algorithm is used only by the verifier.
+This function is only used in the stateful path, and only by the verifier.
 
 ```py
 def wots_c_map_digest(pk_seed: bytes, message_digest: bytes, ADRS: bytearray, counter: int) -> Optional[list[int]]:
+  assert len(pk_seed) == 16
+  assert len(message_digest) == 32
+  assert len(ADRS) == 22
+  assert 0 <= counter < 2**16
   ADRS[9] = SF_WOTS_C_GRIND
   hashed = H_grind(pk_seed, ADRS, message_digest, counter)
   indexes = base_2b(hashed, WOTS_C_CHAIN_BITS, WOTS_C_CHAIN_COUNT)
@@ -945,20 +995,23 @@ def wots_c_map_digest(pk_seed: bytes, message_digest: bytes, ADRS: bytearray, co
 ### `wots_c_pubkey_gen(...)`
 
 <!-- DOC START wots_c_pubkey_gen -->
-The WOTS+C public key generation function. Takes in the secret `sk_seed`, the `pk_seed`, and an
-`ADRS`. The `ADRS` should be prefilled with the location of the WOTS keypair being used.
+The WOTS+C public key generation function. Computes the 16-byte WOTS+C public key at the keypair
+location prefilled in `ADRS`.
 
 - Inputs:
   - `sk_seed`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
-  - A 16-byte hash representing the WOTS+C public key.
+  - a 16-byte hash representing the WOTS+C public key.
 
-This algorithm is used only by the signer.
+This function is only used in the stateful path, and only by the signer.
 
 ```py
 def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   wots_pk = [b''] * WOTS_C_CHAIN_COUNT
   ADRS[10:14] = zeros(4) # zeros reserved
   for i in range(WOTS_C_CHAIN_COUNT):
@@ -980,21 +1033,25 @@ def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
 ### `wots_c_sign(...)`
 
 <!-- DOC START wots_c_sign -->
-The WOTS+C signing function. Takes in a 32-byte `message_digest`, the `sk_seed` and `pk_seed`,
-and an `ADRS`. The `ADRS` should be prefilled with the location of the WOTS keypair being used.
+The WOTS+C signing function. Produces a WOTS+C signature on a 32-byte `message_digest`, at the
+keypair location prefilled in `ADRS`.
 
 - Inputs:
   - `message_digest`: a 32-byte message digest to sign.
   - `sk_seed`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-- Outputs:
-  - A WOTS signature composed of `2 + WOTS_C_CHAIN_COUNT * 16` bytes.
+- Output:
+  - a `2 + WOTS_C_CHAIN_COUNT * 16`-byte signature.
 
-This algorithm is used only by the signer.
+This function is only used in the stateful path, and only by the signer.
 
 ```py
 def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(message_digest) == 32
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   counter, indexes = wots_c_grind_to_constant_sum(pk_seed, message_digest, ADRS)
   signature = [b''] * WOTS_C_CHAIN_COUNT
 
@@ -1014,22 +1071,25 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
 ### `wots_c_pubkey_from_sig(...)`
 
 <!-- DOC START wots_c_pubkey_from_sig -->
-The WOTS+C verification procedure. Recovers a WOTS+C public key from a `signature` on a given
-32-byte `message_digest`. Takes in the `pk_seed`, and an `ADRS`. The `ADRS`
-should be prefilled with the location of the WOTS keypair being used.
+The WOTS+C verification function. Recovers a WOTS+C public key from a `signature` on a 32-byte
+`message_digest`.
 
 - Inputs:
-  - `signature`: a string of `2 + WOTS_C_CHAIN_COUNT * 16` bytes.
+  - `signature`: a `2 + WOTS_C_CHAIN_COUNT * 16`-byte signature.
   - `message_digest`: a 32-byte message digest.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
-  - A 16-byte hash representing the WOTS+C public key, or null.
+  - a 16-byte hash representing the WOTS+C public key, or null.
 
-This algorithm is used only by the verifier.
+This function is only used in the stateful path, and only by the verifier.
 
 ```py
 def wots_c_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes, ADRS: bytearray) -> Optional[bytes]:
+  assert len(signature) == 2 + WOTS_C_CHAIN_COUNT * 16
+  assert len(message_digest) == 32
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   counter = int.from_bytes(signature[0:2])
   indexes = wots_c_map_digest(pk_seed, message_digest, ADRS, counter)
 
@@ -1112,35 +1172,39 @@ These algorithms are used only for the stateless XMSS sub-scheme.
 ### `xmss_node(...)`
 
 <!-- DOC START xmss_node -->
-The XMSS internal node computation helper function. This is a recursive function which takes
-in the `sk_seed`, a target `node_index`, a `node_height`, the `pk_seed`, and an `ADRS`.
-The `ADRS` must be prefilled with the location of the XMSS tree in the hypertree to ensure
-the hashes are properly tweaked.
+The XMSS internal node computation function. Recursively computes the XMSS node at the given
+`node_index` and `node_height`. The `ADRS` must be prefilled with the location of the XMSS tree
+in the hypertree to ensure the hashes are properly tweaked.
 
 - Inputs:
   - `sk_seed`: a 16-byte secret.
-  - `node_index`: An unsigned integer indicating the index (from the left) of the desired node in the XMSS layer.
-  - `node_height`: An unsigned integer indicating the height (from the bottom) of the desired node in the XMSS layer.
+  - `node_index`: a 32-bit unsigned integer, the index (from the left) of the node in the XMSS layer.
+  - `node_height`: a 32-bit unsigned integer, the height (from the bottom) of the node in the XMSS layer.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-- Outputs:
-  - A 16-byte XMSS node hash
+- Output:
+  - a 16-byte XMSS node hash.
 
-This algorithm is used only by the signer.
+This function is only used in the stateless path, and only by the signer.
 
 ```py
 def xmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= node_index < 2**32
+  assert 0 <= node_height < 2**32
   if node_height == 0: # Bottom layer: return the WOTS-TW pubkey hash.
     ADRS[10:14] = node_index.to_bytes(4)
     return wots_tw_pubkey_gen(sk_seed, pk_seed, ADRS)
 
-  # Recursively derive the left/right child nodes
+  # Recursively derive the left/right child nodes.
   lchild_index = 2 * node_index
   child_height = node_height - 1
   lchild = xmss_node(sk_seed, lchild_index, child_height, pk_seed, ADRS)
   rchild = xmss_node(sk_seed, lchild_index + 1, child_height, pk_seed, ADRS)
 
-  # Compute & return the parent node.
+  # Compute and return the parent node.
   ADRS[9] = SL_XMSS_TREE
   ADRS[10:14] = zeros(4)
   ADRS[14:18] = node_height.to_bytes(4)
@@ -1153,29 +1217,33 @@ def xmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes,
 ### `xmss_sign(...)`
 
 <!-- DOC START xmss_sign -->
-The XMSS signing procedure. This function produces a deterministic WOTS-TW signature using a
-specific leaf of a XMSS tree, and appends a merkle authentication path to form a XMSS
-signature. Takes in the `message` to sign, the `sk_seed`, the `keypair_index` to sign with,
-the `pk_seed`, and an `ADRS`. The `ADRS` must be prefilled with the location of the XMSS tree
-in the hypertree to ensure the hashes are properly tweaked.
+The XMSS signing function. Produces a deterministic WOTS-TW signature at leaf `keypair_index` and
+appends the Merkle authentication path to form an XMSS signature. The `ADRS` must be prefilled with
+the location of the XMSS tree in the hypertree to ensure the hashes are properly tweaked.
 
 - Inputs:
   - `message`: a 16-byte message to sign.
   - `sk_seed`: a 16-byte secret.
-  - `keypair_index`: The index of the WOTS-TW keypair to sign with.
+  - `keypair_index`: a 32-bit unsigned integer, the index of the WOTS-TW keypair to sign with.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-- Outputs:
-  - A XMSS signature consisting of `16 * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)` bytes.
+- Output:
+  - a `16 * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)`-byte signature.
 
-This algorithm is used only by the signer.
+This function is only used in the stateless path, and only by the signer.
 
 ```py
 def xmss_sign(message: bytes, sk_seed: bytes, keypair_index: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(message) == 16
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= keypair_index < 2**32
+  # Sign the message with WOTS-TW.
   ADRS[10:14] = keypair_index.to_bytes(4)
   sig = wots_tw_sign(message, sk_seed, pk_seed, ADRS)
 
-  # Append the Merkle authentication path
+  # Append the Merkle authentication path.
   for j in range(SPHX_XMSS_HEIGHT):
     sibling_index = (keypair_index >> j) ^ 1
     sig += xmss_node(sk_seed, sibling_index, j, pk_seed, ADRS)
@@ -1188,24 +1256,28 @@ def xmss_sign(message: bytes, sk_seed: bytes, keypair_index: int, pk_seed: bytes
 ### `xmss_pubkey_from_sig(...)`
 
 <!-- DOC START xmss_pubkey_from_sig -->
-The XMSS verification function. Recovers an XMSS public key from a `signature` on a given
-16-byte `message`. Takes in the `pk_seed`, and an `ADRS`. The exact position of the WOTS-TW
-signing leaf is given by the `keypair_index` argument. The `ADRS` must be prefilled with the
-location of the XMSS tree in the hypertree to ensure the hashes are properly tweaked.
+The XMSS verification function. Recovers an XMSS root from a `signature` on a 16-byte `message`
+at leaf `keypair_index`. The `ADRS` must be prefilled with the location of the XMSS tree in the
+hypertree to ensure the hashes are properly tweaked.
 
 - Inputs:
   - `keypair_index`: a 32-bit unsigned integer, the index of the WOTS-TW keypair to sign with.
-  - `signature`: an XMSS signature consisting of `16 * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)` bytes.
+  - `signature`: a `16 * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)`-byte signature.
   - `message`: a 16-byte message.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
-  - a 16-byte XMSS root node hash
+  - a 16-byte XMSS root node hash.
 
-This algorithm is used both by the signer and the verifier.
+This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
 def xmss_pubkey_from_sig(keypair_index: int, signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(signature) == 16 * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)
+  assert len(message) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= keypair_index < 2**32
   wots_sig = signature[0 : WOTS_TW_CHAIN_COUNT*16]
   xmss_auth = signature[WOTS_TW_CHAIN_COUNT*16 : (WOTS_TW_CHAIN_COUNT+SPHX_XMSS_HEIGHT)*16]
 
@@ -1246,24 +1318,26 @@ The following algorithms are used only for stateless hypertree signing and verif
 ### `hypertree_sign(...)`
 
 <!-- DOC START hypertree_sign -->
-The hypertree signing function. Signs a 16-byte `message`, using a hypertree of XMSS trees. Takes
-in the `sk_seed`, `pk_seed`, the index of the bottom-layer XMSS tree `tree_index`, and the index
-of the WOTS-TW leaf key within that tree `leaf_index`.
+The hypertree signing function. Signs a 16-byte `message` through a hypertree of XMSS trees.
 
 - Inputs:
   - `message`: a 16-byte message to sign.
   - `sk_seed`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
-  - `tree_index`: the index (from the left) of the bottom-layer XMSS tree to sign with.
-  - `leaf_index`: the index (from the left) of the WOTS-TW key in the bottom-layer XMSS tree to sign with.
+  - `tree_index`: a 64-bit unsigned integer, the index (from the left) of the bottom-layer XMSS tree to sign with.
+  - `leaf_index`: a 32-bit unsigned integer, the index (from the left) of the WOTS-TW key in the bottom-layer XMSS tree to sign with.
 - Output:
-  - A hypertree signature, a byte string of length
-    `16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)`
+  - a `16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)`-byte signature.
 
 This function is only used in the stateless path, and only by the signer.
 
 ```py
 def hypertree_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, tree_index: int, leaf_index: int) -> bytes:
+  assert len(message) == 16
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert 0 <= tree_index < 2**64
+  assert 0 <= leaf_index < 2**32
   ADRS = bytearray(22)
 
   sig = b""
@@ -1285,23 +1359,29 @@ def hypertree_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, tree_index: i
 ### `hypertree_verify(...)`
 
 <!-- DOC START hypertree_verify -->
-The hypertree verification procedure. Recovers the root of a hypertree from a hypertree
-`signature`, and compares it against the given `sl_root` hash.
+The hypertree verification function. Recovers the hypertree root from a `signature` and compares
+it against `sl_root`.
 
 - Inputs:
-  - `message`: a 16-byte message to sign.
-  - `signature`: a `16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)` hypertree signature.
+  - `message`: a 16-byte message.
+  - `signature`: a `16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)`-byte signature.
   - `pk_seed`: a 16-byte salt.
-  - `tree_index`: the index (from the left) of the bottom-layer XMSS tree to sign with.
-  - `leaf_index`: the index (from the left) of the WOTS-TW key in the bottom-layer XMSS tree to sign with.
-  - `sl_root`: the 16-byte stateless root hash from the SHRINCS public key.
+  - `tree_index`: a 64-bit unsigned integer, the index (from the left) of the bottom-layer XMSS tree to sign with.
+  - `leaf_index`: a 32-bit unsigned integer, the index (from the left) of the WOTS-TW key in the bottom-layer XMSS tree to sign with.
+  - `sl_root`: the 16-byte root hash of the stateless root tree.
 - Output:
-  - A boolean indicating if the signature is valid.
+  - a boolean indicating if the signature is valid.
 
 This function is only used in the stateless path, and only by the verifier.
 
 ```py
 def hypertree_verify(message: bytes, signature: bytes, pk_seed: bytes, tree_index: int, leaf_index: int, sl_root: bytes) -> bool:
+  assert len(message) == 16
+  assert len(signature) == 16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert 0 <= tree_index < 2**64
+  assert 0 <= leaf_index < 2**32
   ADRS = bytearray(22)
 
   offset = 0
@@ -1426,24 +1506,29 @@ These algorithms are used only for the stateful FXMSS sub-scheme.
 ### `fxmss_node(...)`
 
 <!-- DOC START fxmss_node -->
-The FXMSS internal node computation helper function. This is a recursive function which takes
-in the `sk_seed`, a target `node_index`, a `node_height`, the `pk_seed`, an FXMSS tree
-`structure` identifier, and an `ADRS`.
+The FXMSS internal node computation function. Recursively computes the FXMSS node at the given
+`node_index` and `node_height` for the tree `structure`.
 
 - Inputs:
   - `sk_seed`: a 16-byte secret.
-  - `node_index`: A 64-bit unsigned integer indicating the index (from the left) of the desired node in the FXMSS layer.
-  - `node_height`: An 8-bit unsigned integer indicating the height (from the bottom) of the desired node in the FXMSS tree.
+  - `node_index`: a 64-bit unsigned integer, the index (from the left) of the node in the FXMSS layer.
+  - `node_height`: an 8-bit unsigned integer, the height (from the bottom) of the node in the FXMSS tree.
   - `pk_seed`: a 16-byte salt.
   - `structure`: a 2-byte identifier describing the FXMSS tree structure.
   - `ADRS`: a 22-byte address.
-- Outputs:
-  - A 16-byte FXMSS node hash
+- Output:
+  - a 16-byte FXMSS node hash.
 
-This algorithm is used only by the signer.
+This function is only used in the stateful path, and only by the signer.
 
 ```py
 def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, structure: bytes, ADRS: bytearray) -> bytes:
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(structure) == 2
+  assert len(ADRS) == 22
+  assert 0 <= node_index < 2**64
+  assert 0 <= node_height < 2**8
   node_depth = FXMSS_HEIGHT - node_height
   tree_shape, tree_depth = structure[0], structure[1]
 
@@ -1455,19 +1540,19 @@ def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes
     ADRS[1:9] = node_index.to_bytes(8)
     return wots_c_pubkey_gen(sk_seed, pk_seed, ADRS)
 
-  # Catch and throw if control would enter an infinite resursive loop.
+  # Catch and throw if control would enter an infinite recursive loop.
   if tree_shape == FXMSS_SHAPE_UNBALANCED:
     assert node_index == 0
   elif tree_shape == FXMSS_SHAPE_BALANCED:
     assert node_depth < tree_depth
 
-  # Recursively derive the left/right child nodes
+  # Recursively derive the left/right child nodes.
   lchild_index = 2 * node_index
   child_height = node_height - 1
   lchild = fxmss_node(sk_seed, lchild_index, child_height, pk_seed, structure, ADRS)
   rchild = fxmss_node(sk_seed, lchild_index + 1, child_height, pk_seed, structure, ADRS)
 
-  # Compute & return the parent node.
+  # Compute and return the parent node.
   ADRS[0] = node_height
   ADRS[1:9] = node_index.to_bytes(8)
   ADRS[9] = SF_FXMSS_TREE
@@ -1480,25 +1565,29 @@ def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes
 ### `fxmss_sign(...)`
 
 <!-- DOC START fxmss_sign -->
-The FXMSS signing procedure. This function produces a deterministic WOTS+C signature using a
-specific leaf of an FXMSS tree, and appends a merkle authentication path to form an FXMSS
-signature. Takes in a `message_digest` to sign, the `sk_seed`, the WOTS+C leaf position
-described by `leaf_index` and `leaf_height`, the `pk_seed`, and the tree `structure`.
+The FXMSS signing function. Produces a deterministic WOTS+C signature at the leaf given by
+`leaf_index`/`leaf_height` and appends the Merkle authentication path to form an FXMSS signature.
 
 - Inputs:
   - `message_digest`: a 32-byte message digest.
   - `sk_seed`: a 16-byte secret.
-  - `leaf_index`: A 64-bit unsigned integer indicating the index (from the left) of the signing leaf in the FXMSS layer.
-  - `leaf_height`: An 8-bit unsigned integer indicating the height (from the bottom) of the signing leaf in the FXMSS tree.
+  - `leaf_index`: a 64-bit unsigned integer, the index (from the left) of the signing leaf in the FXMSS layer.
+  - `leaf_height`: an 8-bit unsigned integer, the height (from the bottom) of the signing leaf in the FXMSS tree.
   - `pk_seed`: a 16-byte salt.
   - `structure`: a 2-byte identifier describing the FXMSS tree structure.
-- Outputs:
-  - An FXMSS signature, a byte string with length `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT - leaf_height)`
+- Output:
+  - a `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT - leaf_height)`-byte signature.
 
-This algorithm is used only by the signer.
+This function is only used in the stateful path, and only by the signer.
 
 ```py
 def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_height: int, pk_seed: bytes, structure: bytes) -> bytes:
+  assert len(message_digest) == 32
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(structure) == 2
+  assert 0 <= leaf_index < 2**64
+  assert 0 <= leaf_height < 2**8
   leaf_depth = FXMSS_HEIGHT - leaf_height
 
   # Validate the leaf is positioned correctly for the specified tree structure.
@@ -1513,7 +1602,7 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
   ADRS[1:9] = leaf_index.to_bytes(8)
   sig = wots_c_sign(message_digest, sk_seed, pk_seed, ADRS)
 
-  # Append the Merkle authentication path
+  # Append the Merkle authentication path.
   for j in range(leaf_depth):
     sibling_index = (leaf_index >> j) ^ 1
     sibling_height = leaf_height + j
@@ -1527,39 +1616,40 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
 ### `fxmss_pubkey_from_sig(...)`
 
 <!-- DOC START fxmss_pubkey_from_sig -->
-The FXMSS verification function. Recovers an FXMSS public key from a `signature` on a given
-32-byte `message_digest`. Takes in the `pk_seed`.
-
-The length of the `signature` implies the depth of the WOTS+C signing leaf. The exact
-left/right position of the WOTS+C signing leaf within its layer is given explicitly by the
-`node_index` argument.
+The FXMSS verification function. Recovers an FXMSS root from a `signature` on a 32-byte
+`message_digest`. The signature length implies the leaf depth; `leaf_index` gives its
+left-to-right position.
 
 - Inputs:
-  - `node_index`: a 64-bit unsigned integer.
-  - `signature`: a variable-length FXMSS signature.
-    - Must be at least `2 + 16 * (WOTS_C_CHAIN_COUNT + 1)` bytes long.
-    - Must be no longer than `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT)` bytes long.
-    - Byte length must be 2 more than a multiple of 16.
+  - `leaf_index`: a 64-bit unsigned integer, the left-to-right position of the WOTS+C signing leaf.
+  - `signature`: a variable-length signature of `2 + 16 * (WOTS_C_CHAIN_COUNT + 1)` to `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT)` bytes, with length 2 more than a multiple of 16.
   - `message_digest`: a 32-byte message digest.
   - `pk_seed`: a 16-byte salt.
 - Output:
-  - a 16-byte FXMSS root node hash, or null
+  - a 16-byte FXMSS root node hash, or null.
+
+This function is only used in the stateful path, and only by the verifier.
 
 ```py
-def fxmss_pubkey_from_sig(node_index: int, signature: bytes, message_digest: bytes, pk_seed: bytes) -> Optional[bytes]:
+def fxmss_pubkey_from_sig(leaf_index: int, signature: bytes, message_digest: bytes, pk_seed: bytes) -> Optional[bytes]:
+  assert len(message_digest) == 32
+  assert len(pk_seed) == 16
+  assert 2 + 16 * WOTS_C_CHAIN_COUNT <= len(signature) <= 2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT)
+  assert len(signature) % 16 == 2
+  assert 0 <= leaf_index < 2**64
   wots_sig = signature[0 : 2+WOTS_C_CHAIN_COUNT*16]
   xmss_auth = signature[2+WOTS_C_CHAIN_COUNT*16 : len(signature)]
 
-  node_depth = floor(len(xmss_auth) / 16)
+  leaf_depth = floor(len(xmss_auth) / 16)
 
-  # Ensure node_index describes a valid position in the FXMSS tree.
-  assert node_index < 2 ** min(64, node_depth)
+  # Ensure leaf_index describes a valid position in the FXMSS tree.
+  assert leaf_index < 2 ** min(64, leaf_depth)
 
-  node_height = FXMSS_HEIGHT - node_depth
+  leaf_height = FXMSS_HEIGHT - leaf_depth
 
   ADRS = bytearray(22)
-  ADRS[0] = node_height
-  ADRS[1:9] = node_index.to_bytes(8)
+  ADRS[0] = leaf_height
+  ADRS[1:9] = leaf_index.to_bytes(8)
   node = wots_c_pubkey_from_sig(wots_sig, message_digest, pk_seed, ADRS)
   if node is None:
     return None
@@ -1567,11 +1657,11 @@ def fxmss_pubkey_from_sig(node_index: int, signature: bytes, message_digest: byt
   ADRS[9] = SF_FXMSS_TREE
   ADRS[10:22] = zeros(12)
 
-  for k in range(node_depth):
+  for k in range(leaf_depth):
     ADRS[0] += 1
-    ADRS[1:9] = (node_index >> (k+1)).to_bytes(8)
+    ADRS[1:9] = (leaf_index >> (k+1)).to_bytes(8)
     sibling = xmss_auth[k*16 : (k+1)*16]
-    if (node_index >> k) & 1 == 1:
+    if (leaf_index >> k) & 1 == 1:
       node = H(pk_seed, ADRS, sibling + node)
     else:
       node = H(pk_seed, ADRS, node + sibling)
@@ -1615,30 +1705,32 @@ The following sections describe the algorithms needed for FORS key-generation, s
 ### `fors_sk_gen(...)`
 
 <!-- DOC START fors_sk_gen -->
-The FORS secret preimage generation function. Generates a secret 16-byte preimage from `sk_seed`.
-Takes in `pk_seed`, an `ADRS`, and the `tree_index` to indicate the position of the FORS leaf
-in the forest. The `ADRS` must be prefilled with the location of the FORS keypair to ensure
-the hashes are properly tweaked.
-
+The FORS secret preimage generation function. Generates the secret 16-byte preimage of the FORS
+leaf at forest-wide index `node_index`. The `ADRS` must be prefilled with the location of the FORS
+keypair to ensure the hashes are properly tweaked.
 
 - Inputs:
   - `sk_seed`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-  - `tree_index`: a 32-bit unsigned integer.
+  - `node_index`: a 32-bit unsigned integer, a forest-wide leaf index in `[0, SPHX_FORS_COUNT * 2**SPHX_FORS_HEIGHT)`.
 - Output:
-  - A 16-byte preimage.
+  - a 16-byte preimage.
 
 This function is only used in the stateless path, and only by the signer.
 
-Note the `tree_index` of a FORS leaf or node is _indexed across the entire forest,_ not just
+Note the `node_index` of a FORS leaf or node is _indexed across the entire forest,_ not just
 within a single tree. The index of leaf `l` in tree `t` is `t * 2**SPHX_FORS_HEIGHT + l`.
 
 ```py
-def fors_sk_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray, tree_index: int) -> bytes:
+def fors_sk_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray, node_index: int) -> bytes:
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= node_index < SPHX_FORS_COUNT * 2**SPHX_FORS_HEIGHT
   ADRS[9] = SL_FORS_PRF
   ADRS[14:18] = zeros(4)
-  ADRS[18:22] = tree_index.to_bytes(4)
+  ADRS[18:22] = node_index.to_bytes(4)
   return PRF(pk_seed, sk_seed, ADRS)
 ```
 <!-- DOC END fors_sk_gen -->
@@ -1647,19 +1739,18 @@ def fors_sk_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray, tree_index: int
 ### `fors_node(...)`
 
 <!-- DOC START fors_node -->
-The FORS internal merkle node computation helper function. This is a recursive function which
-takes in the `sk_seed`, `pk_seed`, an `ADRS`, and integers `node_height`, `node_index` which
-describe the position of the FORS node in the forest of merkle trees. The `ADRS` must be
-prefilled with the location of the FORS keypair to ensure the hashes are properly tweaked.
+The FORS internal node computation function. Recursively computes the FORS node at the forest-wide
+`node_index` and `node_height`. The `ADRS` must be prefilled with the location of the FORS keypair
+to ensure the hashes are properly tweaked.
 
 - Inputs:
   - `sk_seed`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
-  - `node_index`: a 32-bit unsigned integer.
-  - `node_height`: a 32-bit unsigned integer.
+  - `node_index`: a 32-bit unsigned integer, a forest-wide node index in `[0, SPHX_FORS_COUNT * 2**(SPHX_FORS_HEIGHT - node_height))`.
+  - `node_height`: a 32-bit unsigned integer, a node height in `[0, SPHX_FORS_HEIGHT]`.
 - Output:
-  - A 16-byte FORS node hash.
+  - a 16-byte FORS node hash.
 
 This function is only used in the stateless path, and only by the signer.
 
@@ -1669,6 +1760,11 @@ within a single tree. The index of node `l` in tree `t` at height `h` is
 
 ```py
 def fors_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= node_height <= SPHX_FORS_HEIGHT
+  assert 0 <= node_index < SPHX_FORS_COUNT * 2**(SPHX_FORS_HEIGHT - node_height)
   if node_height == 0:
     preimage = fors_sk_gen(sk_seed, pk_seed, ADRS, node_index)
     ADRS[9] = SL_FORS_TREE
@@ -1692,23 +1788,25 @@ def fors_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes,
 ### `fors_sign(...)`
 
 <!-- DOC START fors_sign -->
-The FORS signing function. Signs a `message_digest`, using `sk_seed` and `pk_seed`, with the
-location of the FORS leaf specified in `ADRS`. The `ADRS` must be prefilled with the location
-of the FORS keypair to ensure the hashes are properly tweaked.
+The FORS signing function. Produces a FORS signature on a `message_digest`. The `ADRS` must be
+prefilled with the location of the FORS keypair to ensure the hashes are properly tweaked.
 
 - Inputs:
-  - `message_digest`: a digest of a message to sign.
-    - Must be exactly `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)` bytes long.
+  - `message_digest`: a `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)`-byte message digest.
   - `sk_seed`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
-  - A FORS signature, a byte string of length `16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)`.
+  - a `16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)`-byte signature.
 
 This function is only used in the stateless path, and only by the signer.
 
 ```py
 def fors_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(message_digest) == ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   sig = b""
   index_set = base_2b(message_digest, SPHX_FORS_HEIGHT, SPHX_FORS_COUNT)
   for i in range(SPHX_FORS_COUNT):
@@ -1725,23 +1823,26 @@ def fors_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytea
 ### `fors_pubkey_from_sig(...)`
 
 <!-- DOC START fors_pubkey_from_sig -->
-The FORS verification procedure. Recovers a FORS public key hash from the given `signature` on a
-`message_digest`. Takes in a `pk_seed` and `ADRS`. The `ADRS` must be prefilled with the location
-of the FORS keypair to ensure the hashes are properly tweaked.
+The FORS verification function. Recovers a FORS public key from a `signature` on a
+`message_digest`. The `ADRS` must be prefilled with the location of the FORS keypair to ensure
+the hashes are properly tweaked.
 
 - Inputs:
-  - `signature`: a byte string of length `16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)`.
-  - `message_digest`: a digest of a message to sign.
-    - Must be exactly `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)` bytes long.
+  - `signature`: a `16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)`-byte signature.
+  - `message_digest`: a `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)`-byte message digest.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
-  - A 16-byte hash of the FORS public key.
+  - a 16-byte hash of the FORS public key.
 
-This function is only used in the stateless path.
+This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
 def fors_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  assert len(signature) == 16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)
+  assert len(message_digest) == ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   index_set = base_2b(message_digest, SPHX_FORS_HEIGHT, SPHX_FORS_COUNT)
 
   offset = 0
@@ -1797,25 +1898,27 @@ The following sections describe the algorithms used for SLH-DSA.
 ### `slh_dsa_digest_message(...)`
 
 <!-- DOC START slh_dsa_digest_message -->
-The SLH-DSA message hashing function. Derives a FORS message digest, tree index, and FORS leaf index
-by hashing a randomizer `R`, `pk_seed`, `sl_root`, and `message`. This is an internal helper
-function which partitions and parses the output of `H_msg_sl` into the pseudorandom digest outputs
-needed for SLH-DSA signing and verification.
+The SLH-DSA message hashing function. Derives the FORS message digest, bottom-layer XMSS tree
+index, and FORS leaf index from `message` under `H_msg_sl`.
 
 - Inputs:
   - `R`: a 16-byte randomizer.
   - `pk_seed`: a 16-byte salt.
   - `sl_root`: the 16-byte root hash of the stateless root tree.
-  - `message`: an arbitrary-length byte string.
+  - `message`: a message of at most `2**61 - 1 - 48` bytes.
 - Outputs:
   - a `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)`-byte message digest, ready for use by FORS.
-  - a pseudorandomly selected index of a bottom-layer XMSS tree (less than `2**(SPHX_XMSS_HEIGHT * (SPHX_LAYER_COUNT - 1))`).
-  - a pseudorandomly selected index of a FORS key within an XMSS tree (less than `2**SPHX_XMSS_HEIGHT`).
+  - a pseudorandomly selected index of a bottom-layer XMSS tree, in `[0, 2**(SPHX_XMSS_HEIGHT * (SPHX_LAYER_COUNT - 1)))`.
+  - a pseudorandomly selected index of a FORS key within an XMSS tree, in `[0, 2**SPHX_XMSS_HEIGHT)`.
 
-This function is used only in the stateless path, by both signer and verifier.
+This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
 def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: bytes) -> Tuple[bytes, int, int]:
+  assert len(R) == 16
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert len(message) <= 2**61 - 1 - 48
   digest = H_msg_sl(R, pk_seed, sl_root, message)
 
   fors_digest = digest[:ceil(SPHX_FORS_HEIGHT * SPHX_FORS_COUNT / 8)]
@@ -1836,9 +1939,9 @@ def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: by
 ### `slh_dsa_sign_internal(...)`
 
 <!-- DOC START slh_dsa_sign_internal -->
-The SLH-DSA internal signing function. Signs a given `message` with `sk_seed`, using `pk_seed` to
-salt all hash function invocations, using `sk_prf` and `opt_rand` to generate an unpredictable
-randomizer, and binds the signature to the given `sl_root`.
+The SLH-DSA internal signing function. Signs `message` with `sk_seed`, salting all hashes with
+`pk_seed`, deriving the randomizer from `sk_prf`/`opt_rand`, and binding the signature to
+`sl_root`.
 
 The optional additional data `opt_rand` is used to further salt the randomizer. If omitted,
 the algorithm uses `pk_seed` in its place, resulting in the _deterministic variant_ of SLH-DSA.
@@ -1847,20 +1950,25 @@ The resulting signature is composed of (1) a randomizer, (2) a FORS signature, a
 hypertree signature, all concatenated together.
 
 - Inputs:
-  - `message`: an arbitrary-length byte string.
+  - `message`: a message of at most `2**61 - 1 - 80` bytes.
   - `sk_seed`: a 16-byte secret.
   - `sk_prf`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
   - `sl_root`: the 16-byte root hash of the stateless root tree.
-  - `opt_rand`: (optional) a 16-byte string used to salt the randomizer.
+  - `opt_rand`: an optional 16-byte salt for the randomizer.
 - Output:
-  - An SLH-DSA signature, of length
-  `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`
+  - a `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`-byte signature.
 
 This function is only used in the stateless path, and only by the signer.
 
 ```py
 def slh_dsa_sign_internal(message: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed: bytes, sl_root: bytes, opt_rand: Optional[bytes]) -> bytes:
+  assert len(sk_seed) == 16
+  assert len(sk_prf) == 16
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert opt_rand is None or len(opt_rand) == 16
+  assert len(message) <= 2**61 - 1 - 80
   if opt_rand is None:
     opt_rand = pk_seed # deterministic mode
 
@@ -1883,22 +1991,24 @@ def slh_dsa_sign_internal(message: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed
 ### `slh_dsa_verify_internal`
 
 <!-- DOC START slh_dsa_verify_internal -->
-The SLH-DSA internal verification procedure. Recovers the root hash of the root tree from a
-`signature` on a given `message`, and checks it against `sl_root`.
+The SLH-DSA internal verification function. Recovers the root-tree root from a `signature` on
+`message` and checks it against `sl_root`.
 
 - Inputs:
-  - `message`: an arbitrary-length byte string.
-  - `signature`: an SLH-DSA signature of length
-    `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`
+  - `message`: a message of at most `2**61 - 1 - 80` bytes.
+  - `signature`: a `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`-byte signature.
   - `pk_seed`: a 16-byte salt.
   - `sl_root`: the 16-byte root hash of the stateless root tree.
 - Output:
-  - A boolean indicating if the signature is valid.
+  - a boolean indicating if the signature is valid.
 
 This function is only used in the stateless path, and only by the verifier.
 
 ```py
 def slh_dsa_verify_internal(message: bytes, signature: bytes, pk_seed: bytes, sl_root: bytes) -> bool:
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert len(message) <= 2**61 - 1 - 80
   if len(signature) != 16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)):
     return False
 
@@ -1922,31 +2032,35 @@ def slh_dsa_verify_internal(message: bytes, signature: bytes, pk_seed: bytes, sl
 ### `slh_dsa_sign(...)`
 
 <!-- DOC START slh_dsa_sign -->
-The SLH-DSA external signing function. Signs a given `message` with `sk_seed`, using `pk_seed` to
-salt all hash function invocations, using `sk_prf` and `opt_rand` to generate an unpredictable
-randomizer, and binds the signature to the given `sl_root`.
+The SLH-DSA external signing function. Signs `message` with `sk_seed`, prepending the context
+`ctx`; salts all hashes with `pk_seed`, derives the randomizer from `sk_prf`/`opt_rand`, and
+binds to `sl_root`.
 
 - Inputs:
-  - `message`: an arbitrary-length byte string.
-  - `ctx`: a variable-length context byte string.
-    - Must be at most 255 bytes long.
+  - `message`: a message of at most `2**61 - 1 - 82 - len(ctx)` bytes.
+  - `ctx`: a context of at most 255 bytes.
   - `sk_seed`: a 16-byte secret.
   - `sk_prf`: a 16-byte secret.
   - `pk_seed`: a 16-byte salt.
   - `sl_root`: the 16-byte root hash of the stateless root tree.
-  - `opt_rand`: (optional) a 16-byte string used to salt the randomizer.
+  - `opt_rand`: an optional 16-byte salt for the randomizer.
 - Output:
-  - An SLH-DSA signature, of length
-  `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`
+  - a `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`-byte signature.
 
 This function is only used in the stateless path, and only by the signer.
 
-This is a simple wrapper around `slh_dsa_sign_internal` which prepends an optional context string
-`ctx` to every message. Verifiers must use `slh_dsa_verify` with the same `ctx` string.
+This is a simple wrapper around `slh_dsa_sign_internal` which prepends an optional context
+`ctx` to every message. Verifiers must use `slh_dsa_verify` with the same `ctx`.
 
 ```py
 def slh_dsa_sign(message: bytes, ctx: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed: bytes, sl_root: bytes, opt_rand: Optional[bytes]) -> bytes:
   assert len(ctx) < 256
+  assert len(sk_seed) == 16
+  assert len(sk_prf) == 16
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert opt_rand is None or len(opt_rand) == 16
+  assert len(message) <= 2**61 - 1 - 82 - len(ctx)
   contextualized_msg = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + message
   return slh_dsa_sign_internal(contextualized_msg, sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
 ```
@@ -1956,28 +2070,29 @@ def slh_dsa_sign(message: bytes, ctx: bytes, sk_seed: bytes, sk_prf: bytes, pk_s
 ### `slh_dsa_verify(...)`
 
 <!-- DOC START slh_dsa_verify -->
-The SLH-DSA verification procedure. Recovers the root hash of the root tree from a `signature`
-on a given `message`, and checks it against `sl_root`.
+The SLH-DSA verification function. Recovers the root-tree root from a `signature` on `message`
+(with context `ctx`) and checks it against `sl_root`.
 
 - Inputs:
-  - `message`: an arbitrary-length byte string.
-  - `signature`: an SLH-DSA signature of length
-    `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`
-  - `ctx`: a variable-length context byte string.
-    - Must be at most 255 bytes long.
+  - `message`: a message of at most `2**61 - 1 - 82 - len(ctx)` bytes.
+  - `signature`: a `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`-byte signature.
+  - `ctx`: a context of at most 255 bytes.
   - `pk_seed`: a 16-byte salt.
   - `sl_root`: the 16-byte root hash of the stateless root tree.
 - Output:
-  - A boolean indicating if the signature is valid.
+  - a boolean indicating if the signature is valid.
 
 This function is only used in the stateless path, and only by the verifier.
 
-This is a simple wrapper around `slh_dsa_verify_internal` which prepends an optional context string
-`ctx` to every message. Signatures must use be produced via `slh_dsa_sign` with the same `ctx` string.
+This is a simple wrapper around `slh_dsa_verify_internal` which prepends an optional context
+`ctx` to every message. Signatures must be produced via `slh_dsa_sign` with the same `ctx`.
 
 ```py
 def slh_dsa_verify(message: bytes, signature: bytes, ctx: bytes, pk_seed: bytes, sl_root: bytes) -> bool:
   assert len(ctx) < 256
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert len(message) <= 2**61 - 1 - 82 - len(ctx)
   contextualized_msg = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + message
   return slh_dsa_verify_internal(contextualized_msg, signature, pk_seed, sl_root)
 ```
@@ -2034,15 +2149,17 @@ The following sections describe algorithms used for SHRINCS.
 ### `shrincs_keygen(...)`
 
 <!-- DOC START shrincs_keygen -->
-The SHRINCS key-generation procedure. Computes secret and public keys from a given 48-byte `seed`
-and the `sf_structure` of the stateful FXMSS tree.
+The SHRINCS key generation function. Computes the secret and public keys from a 48-byte `seed`
+and the stateful tree `sf_structure`.
 
 - Inputs:
   - `seed`: a 48-byte random seed. Must be sampled from a CSRNG.
   - `sf_structure`: a 2-byte identifier describing the shape and depth of the stateful FXMSS tree.
 - Outputs:
-  - the SHRINCS secret key, of length 82 bytes.
-  - the SHRINCS public key, of length 48 bytes.
+  - an 82-byte SHRINCS secret key.
+  - a 48-byte SHRINCS public key.
+
+This function is used only during key generation.
 
 > [!WARNING]
 > The `sf_structure` argument must come from a trusted source or else be validated.
@@ -2073,17 +2190,16 @@ def shrincs_keygen(seed: bytes, sf_structure: bytes) -> Tuple[bytes, bytes]:
 ### `shrincs_sf_leaf_select(...)`
 
 <!-- DOC START shrincs_sf_leaf_select -->
-The SHRINCS stateful path leaf selection algorithm. Given an FXMSS tree `structure` and the
-current `state_ctr` counter, this function computes the position of the next WOTS+C leaf in
-the FXMSS tree, returned as a tuple of `(index, height)` integers.
+The SHRINCS stateful-path leaf-selection function. Computes the position `(index, height)` of the
+next WOTS+C leaf for the given `structure` and `state_ctr`.
 
 - Inputs:
   - `structure`: a 2-byte identifier describing the FXMSS tree structure.
-  - `state_ctr`: an integer indicating how many stateful signatures the SHRINCS keypair has
-    previously issued.
+  - `state_ctr`: a signed integer, the number of stateful signatures the keypair has
+    previously issued (a negative value is explicitly invalid).
 - Outputs:
-  - The left-to-right index of the next WOTS+C leaf in the FXMSS tree that should be used.
-  - The bottom-to-top height of the next WOTS+C leaf in the FXMSS tree that should be used.
+  - a 64-bit unsigned integer, the left-to-right index of the next WOTS+C leaf in the FXMSS tree.
+  - an 8-bit unsigned integer, the bottom-to-top height of the next WOTS+C leaf in the FXMSS tree.
 
 Returns `None` if `state_ctr` is set to any negative number, or if `state_ctr + 1` exceeds the
 number of WOTS+C leaves in the FXMSS tree (as defined by its structure).
@@ -2092,6 +2208,7 @@ This function is only used in the stateful path, and only by the signer.
 
 ```py
 def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[Tuple[int, int]]:
+  assert len(structure) == 2
   tree_shape, tree_depth = structure[0], structure[1]
   if tree_shape == FXMSS_SHAPE_UNBALANCED:
     if state_ctr == tree_depth and tree_depth > 0:
@@ -2115,24 +2232,21 @@ def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[Tuple[i
 ### `shrincs_sign(...)`
 
 <!-- DOC START shrincs_sign -->
-The SHRINCS signing function. Signs `message` with the serialized SHRINCS secret key
-`shrincs_seckey`. If `state_ctr` is non-negative and valid for the stateful tree
-structure specified in the secret key, then this function will use the stateful path and
-will return a variable-length FXMSS signature. Otherwise it will fall back to the
-stateless signing path and use SLH-DSA to sign the message.
+The SHRINCS signing function. Signs `message` with the serialized secret key `shrincs_seckey`:
+uses the stateful FXMSS path when `state_ctr` is valid for the key's tree structure, otherwise
+falls back to the stateless SLH-DSA path.
 
 - Inputs:
-  - `message`: an arbitrary-length byte string.
+  - `message`: a message of at most `2**61 - 1 - 98` bytes.
   - `shrincs_seckey`: an 82-byte SHRINCS secret key.
-  - `state_ctr`: an integer indicating how many stateful signatures the SHRINCS keypair has
-    previously issued.
-  - `opt_rand`: (optional) a 16-byte string used to salt the randomizer in SLH-DSA. Not used
-    in the stateful signing path. If omitted, the stateless signing path will use the
-    deterministic variant of SLH-DSA.
+  - `state_ctr`: a signed integer, the number of stateful signatures the keypair has
+    previously issued (a negative value is explicitly invalid).
+  - `opt_rand`: an optional 16-byte salt for the randomizer in SLH-DSA (unused in the stateful path;
+    if omitted, the stateless path uses the deterministic variant of SLH-DSA).
 - Output:
-  - A variable-length SHRINCS signature (a byte string).
+  - a variable-length SHRINCS signature.
 
-This function is only used by the signer.
+This function is used only by the signer.
 
 > [!CAUTION]
 > Using the same key to sign different `message` values with the same `state_ctr` is
@@ -2145,6 +2259,10 @@ This function is only used by the signer.
 
 ```py
 def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand: Optional[bytes]) -> bytes:
+  assert len(shrincs_seckey) == 82
+  assert opt_rand is None or len(opt_rand) == 16
+  assert len(message) <= 2**61 - 1 - 98
+
   sk_seed      = shrincs_seckey[0:16]
   sk_prf       = shrincs_seckey[16:32]
   pk_seed      = shrincs_seckey[32:48]
@@ -2156,7 +2274,7 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
 
   # Stateless signing path.
   if leaf_position is None:
-    # bind the stateless signature to the stateful keypair.
+    # Bind the stateless signature to the stateful keypair.
     return slh_dsa_sign(sf_root + message, b"", sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
 
   # Stateful signing path.
@@ -2166,7 +2284,7 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   ADRS[1:9] = leaf_index.to_bytes(8)
   R = PRF_msg_sf(sk_prf, pk_seed, ADRS, message)
 
-  # bind the stateful signature to the stateless keypair.
+  # Bind the stateful signature to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, sl_root + message)
   fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, sf_structure)
 
@@ -2179,34 +2297,37 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
 ### `shrincs_verify(...)`
 
 <!-- DOC START shrincs_verify -->
-The SHRINCS verification procedure. Returns true if `signature` is a valid stateful
-or stateless SHRINCS signature on `message`, issued by the given `shrincs_pubkey`.
+The SHRINCS verification function. Returns true iff `signature` is a valid stateful or stateless
+SHRINCS signature on `message` under `shrincs_pubkey`.
 
 Based on the length of `signature`, the verifier either recomputes `sf_root`
 (stateful path) or recomputes `sl_root` (stateless path), and compares the result
 against the public key.
 
 - Inputs:
-  - `message`: an arbitrary-length byte string.
-  - `signature`: an arbitrary-length byte string, claimed to be a SHRINCS signature.
-  - `shrincs_pubkey`: an 48-byte SHRINCS public key.
+  - `message`: a message of at most `2**61 - 1 - 98` bytes.
+  - `signature`: a purported SHRINCS signature of arbitrary length.
+  - `shrincs_pubkey`: a 48-byte SHRINCS public key.
 - Output:
-  - A boolean indicating if the signature is valid.
+  - a boolean indicating if the signature is valid.
 
 This function is used only by the verifier.
 
 ```py
 def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> bool:
+  assert len(shrincs_pubkey) == 48
+  assert len(message) <= 2**61 - 1 - 98
+
   pk_seed = shrincs_pubkey[0:16]
   sl_root = shrincs_pubkey[16:32]
   sf_root = shrincs_pubkey[32:48]
 
-  # Stateless verification path
+  # Stateless verification path.
   if len(signature) == 16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)):
-    # stateless signatures must be bound to the stateful keypair.
+    # Stateless signatures must be bound to the stateful keypair.
     return slh_dsa_verify(sf_root + message, signature, b"", pk_seed, sl_root)
 
-  # Stateful verification path
+  # Stateful verification path.
   if len(signature) < 24:
     return False
 
@@ -2225,13 +2346,18 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
     return False
 
   leaf_depth = (len(fxmss_signature) - 2) // 16 - WOTS_C_CHAIN_COUNT
+
+  # Reject a leaf_index that names no position in a tree of this depth
+  if leaf_index >= 2 ** min(64, leaf_depth):
+    return False
+
   leaf_height = FXMSS_HEIGHT - leaf_depth
 
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
 
-  # stateful signatures must be bound to the stateless keypair.
+  # Stateful signatures must be bound to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, sl_root + message)
   root = fxmss_pubkey_from_sig(leaf_index, fxmss_signature, message_digest, pk_seed)
   return root is not None and root == sf_root

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -5,9 +5,12 @@ from typing import Optional, Tuple
 #  Helper functions
 
 def repeat(b: int, n: int) -> bytes:
+  assert 0 <= b < 2**8
+  assert 0 <= n
   return bytes((b for _ in range(n)))
 
 def zeros(n: int) -> bytes:
+  assert 0 <= n
   return repeat(0, n)
 
 def concat(array: list[bytes]) -> bytes:
@@ -22,7 +25,7 @@ def xor(s1: bytes, s2: bytes) -> bytes:
 
 def base_2b(x: bytes, b: int, outlen: int) -> list[int]:
   """
-  Decomposes a byte string `x` into `outlen` groups of `b` bits which are each
+  Decomposes the bytes `x` into `outlen` groups of `b` bits which are each
   parsed as an integer in the range `[0, 2**b)`. The leading `outlen * b` bits
   of `x` are parsed, and so `x` must have accordingly sufficient length.
   """
@@ -83,12 +86,14 @@ SF_WOTS_C_GRIND = 22
 #  Primitive cryptographic functions
 
 def sha256(message: bytes) -> bytes:
+  assert len(message) <= 2**61 - 1
   return hashlib.sha256(bytes(message)).digest()
 
-def hmac_sha256(key: bytes, msg: bytes) -> bytes:
+def hmac_sha256(key: bytes, message: bytes) -> bytes:
   assert len(key) <= 64
+  assert len(message) <= 2**61 - 1 - 64
   padded_key = key + zeros(64 - len(key))
-  inner = sha256(xor(padded_key, repeat(0x36, 64)) + msg)
+  inner = sha256(xor(padded_key, repeat(0x36, 64)) + message)
   return sha256(xor(padded_key, repeat(0x5C, 64)) + inner)
 
 
@@ -96,177 +101,196 @@ def hmac_sha256(key: bytes, msg: bytes) -> bytes:
 
 def T_sl(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
   """
-  Hashes an input `M_l`, which is a sequence of `WOTS_TW_CHAIN_COUNT` hashes, each 16 bytes long,
-  concatenated together. This function will be used to compress Winternitz chain tips to a single
-  hash in SLH-DSA.
+  The `T_sl` tweaked hash function. Compresses `WOTS_TW_CHAIN_COUNT` Winternitz chain tips into a
+  single 16-byte hash.
 
   - Inputs:
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-    - `M_l`: an array of `WOTS_TW_CHAIN_COUNT * 16` bytes.
+    - `M_l`: a `WOTS_TW_CHAIN_COUNT * 16`-byte concatenation of chain tips.
   - Output:
-    - A 16-byte hash.
+    - a 16-byte hash.
 
-  This function is only used in the stateless path.
+  This function is only used in the stateless path, and by both the signer and the verifier.
   """
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_l) == WOTS_TW_CHAIN_COUNT * 16
   return sha256(pk_seed + zeros(48) + ADRS + M_l)[:16]
 
 def T_sf(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
   """
-  Hashes an input `M_l`, which is a sequence of `WOTS_C_CHAIN_COUNT` hashes, each 16 bytes long,
-  concatenated together. This function will be used to compress Winternitz chain tips to a single
-  hash in FXMSS.
+  The `T_sf` tweaked hash function. Compresses `WOTS_C_CHAIN_COUNT` Winternitz chain tips into a
+  single 16-byte hash.
 
   - Inputs:
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-    - `M_l`: an array of `WOTS_C_CHAIN_COUNT * 16` bytes.
+    - `M_l`: a `WOTS_C_CHAIN_COUNT * 16`-byte concatenation of chain tips.
   - Output:
-    - A 16-byte hash.
+    - a 16-byte hash.
 
-  This function is only used in the stateful path.
+  This function is only used in the stateful path, and by both the signer and the verifier.
   """
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_l) == WOTS_C_CHAIN_COUNT * 16
   return sha256(pk_seed + zeros(48) + ADRS + M_l)[:16]
 
 def T_k(pk_seed: bytes, ADRS: bytearray, M_k: bytes) -> bytes:
   """
-  Hashes an input `M_k`, which is a sequence of `SPHX_FORS_COUNT` hashes, each 16 bytes long,
-  concatenated together. This function will be used to compress FORS tree roots to a single
-  hash in the stateless path.
+  The `T_k` tweaked hash function. Compresses `SPHX_FORS_COUNT` FORS tree roots into a single
+  16-byte hash.
 
   - Inputs:
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-    - `M_k`: an array of `SPHX_FORS_COUNT * 16` bytes.
+    - `M_k`: a `SPHX_FORS_COUNT * 16`-byte concatenation of FORS tree roots.
   - Output:
-    - A 16-byte hash.
+    - a 16-byte hash.
 
-  This function is only used in the stateless path.
+  This function is only used in the stateless path, and by both the signer and the verifier.
   """
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_k) == SPHX_FORS_COUNT * 16
   return sha256(pk_seed + zeros(48) + ADRS + M_k)[:16]
 
 def F(pk_seed: bytes, ADRS: bytearray, M_1: bytes) -> bytes:
   """
-  Hashes an input `M_1`, which is a single 16-byte hash. This function will be used to generate
-  and iterate Winternitz hash chains and to hash FORS leaves.
+  The `F` tweaked hash function. Hashes a single 16-byte input, to generate and iterate Winternitz
+  hash chains and to hash FORS leaves.
 
   - Inputs:
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
     - `M_1`: a 16-byte hash.
   - Output:
-    - A 16-byte hash.
+    - a 16-byte hash.
 
-  This function is used in both stateful and stateless paths.
+  This function is used in both stateful and stateless paths, and by both the signer and the verifier.
   """
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_1) == 16
   return sha256(pk_seed + zeros(48) + ADRS + M_1)[:16]
 
 def H(pk_seed: bytes, ADRS: bytearray, M_2: bytes) -> bytes:
   """
-  Hashes an input `M_2`, which is a pair of 16-byte hashes, concatenated together. This function
-  will be used to combine pairs of merkle nodes, to construct merkle trees in XMSS and FORS.
+  The `H` tweaked hash function. Combines a pair of 16-byte Merkle child nodes into their 16-byte
+  parent, building the Merkle trees in XMSS and FORS.
 
   - Inputs:
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-    - `M_2`: an array of 32 bytes.
+    - `M_2`: a 32-byte concatenation of two child node hashes.
   - Output:
-    - A 16-byte hash.
+    - a 16-byte hash.
 
-  This function is used in both stateful and stateless paths.
+  This function is used in both stateful and stateless paths, and by both the signer and the verifier.
   """
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M_2) == 32
   return sha256(pk_seed + zeros(48) + ADRS + M_2)[:16]
 
 def H_grind(pk_seed: bytes, ADRS: bytearray, digest: bytes, counter: int) -> bytes:
   """
-  Hashes a 32-byte message `digest` and a grinding `counter`. This function will be used to
-  map `digest` into a constant-sum message space for WOTS+C. Also takes in `pk_seed` and
-  a WOTS+C leaf `ADRS`.
-
+  The `H_grind` tweaked hash function. Maps a 32-byte `digest` and grinding `counter` into the
+  constant-sum message space for WOTS+C.
 
   - Inputs:
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-    - `digest`: an array of 32 bytes.
+    - `digest`: a 32-byte digest.
     - `counter`: a 16-bit unsigned integer.
   - Output:
-    - A 16-byte hash.
+    - a 16-byte hash.
 
-  This function is only used in the stateful path.
+  This function is only used in the stateful path, and by both the signer and the verifier.
   """
-  assert counter <= 0xFFFF
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(digest) == 32
+  assert 0 <= counter < 2**16
   return sha256(pk_seed + zeros(48) + ADRS[:10] + digest + zeros(4) + counter.to_bytes(2))[:16]
 
 def PRF(pk_seed: bytes, sk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  Hashes `sk_seed` with an `ADRS` to derive secret preimage values needed for signing and key
-  generation.
+  The `PRF` tweaked hash function. Derives a secret 16-byte preimage from `sk_seed`, for signing
+  and key generation.
 
   - Inputs:
     - `pk_seed`: a 16-byte salt.
     - `sk_seed`: a 16-byte secret.
     - `ADRS`: a 22-byte address.
   - Output:
-    - A 16-byte hash.
+    - a 16-byte hash.
 
-  This function is used in both stateful and stateless paths, but only by the signing algorithm.
+  This function is used in both stateful and stateless paths, but only by the signer.
   """
+  assert len(pk_seed) == 16
+  assert len(sk_seed) == 16
+  assert len(ADRS) == 22
   return sha256(pk_seed + zeros(48) + ADRS + sk_seed)[:16]
 
 def H_msg_sl(R: bytes, pk_seed: bytes, root: bytes, M: bytes) -> bytes:
   """
-  Hashes a _randomizer_ `R`, the `pk_seed`, a merkle root `root`, and an arbitrary-length message
-  bytestring `M`. It will be used to produce a digest for signing in the stateless path.
+  The `H_msg_sl` message hash function. Produces the 32-byte signing digest for the stateless path.
 
   - Inputs:
     - `R`: a 16-byte randomizer.
     - `pk_seed`: a 16-byte salt.
     - `root`: a 16-byte hash.
-    - `M`: an arbitrary-length bytestring (TODO).
+    - `M`: a message of at most `2**61 - 1 - 48` bytes.
   - Output:
-    - A 32-byte hash.
+    - a 32-byte hash.
 
-  This function is only used in the stateless path.
+  This function is only used in the stateless path, and by both the signer and the verifier.
 
   Note that `pk_seed` is not padded in this tweakable hash function.
   """
+  assert len(R) == 16
+  assert len(pk_seed) == 16
+  assert len(root) == 16
+  assert len(M) <= 2**61 - 1 - 48
   return sha256(R + pk_seed + sha256(R + pk_seed + root + M) + zeros(4))
 
 def H_msg_sf(R: bytes, pk_seed: bytes, root: bytes, ADRS: bytearray, M: bytes) -> bytes:
   """
-  Hashes a _randomizer_ `R`, the `pk_seed`, a WOTS+C leaf `ADRS`, a merkle root `root`,
-  and an arbitrary-length message bytestring `M`. It will be used to produce a digest for
-  signing in the stateful path.
-
-  TODO: can `ADRS[:9]` be used only once?
+  The `H_msg_sf` message hash function. Produces the 32-byte signing digest for the stateful path.
 
   - Inputs:
     - `R`: a 16-byte randomizer.
     - `pk_seed`: a 16-byte salt.
     - `root`: a 16-byte hash.
     - `ADRS`: a 22-byte address.
-    - `M`: an arbitrary-length bytestring (TODO).
+    - `M`: a message of at most `2**61 - 1 - 57` bytes.
   - Output:
-    - A 32-byte hash.
+    - a 32-byte hash.
 
-  This function is only used in the stateful path.
+  This function is only used in the stateful path, and by both the signer and the verifier.
 
   Note that `pk_seed` is not padded in this tweakable hash function.
   """
+  assert len(R) == 16
+  assert len(pk_seed) == 16
+  assert len(root) == 16
+  assert len(ADRS) == 22
+  assert len(M) <= 2**61 - 1 - 57
   return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + root + ADRS[:9] + M))
 
 def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   """
-  Uses HMAC-SHA256 to hash `sk_prf`, randomness `opt_rand`, and an arbitrary-length message `M`.
-  This function will be used to derive a _randomizer_ (salt) for the given message in
-  the stateless path.
+  The `PRF_msg_sl` function. Derives the per-message randomizer (salt) for the stateless path via
+  HMAC-SHA256.
 
   - Inputs:
     - `sk_prf`: a 16-byte secret.
     - `opt_rand`: a 16-byte salt.
-    - `M`: an arbitrary-length bytestring (TODO).
+    - `M`: a message of at most `2**61 - 1 - 80` bytes.
   - Output:
-    - A 16-byte hash.
+    - a 16-byte hash.
 
   This function is only used in the stateless path, and only by the signer.
 
@@ -274,47 +298,58 @@ def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA, which increases
   resistance to side-channel attacks).
   """
-  return hmac_sha256(key=sk_prf, msg=opt_rand + M)[:16]
+  assert len(sk_prf) == 16
+  assert len(opt_rand) == 16
+  assert len(M) <= 2**61 - 1 - 80
+  return hmac_sha256(key=sk_prf, message=opt_rand + M)[:16]
 
 def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> bytes:
   """
-  Uses HMAC-SHA256 to hash `sk_prf`, the `pk_seed`, an `ADRS`, and an arbitrary-length message `M`. This function
-  will be used to derive a _randomizer_ (salt) for the given message in the stateful path.
+  The `PRF_msg_sf` function. Derives the per-message randomizer (salt) for the stateful path via
+  HMAC-SHA256.
 
   - Inputs:
     - `sk_prf`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-    - `M`: an arbitrary-length bytestring (TODO).
+    - `M`: a message of at most `2**61 - 1 - 89` bytes.
   - Output:
-    - A 16-byte hash.
+    - a 16-byte hash.
 
   This function is only used in the stateful path, and only by the signer.
   """
-  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), msg=pk_seed + ADRS[:9] + M)[:16]
+  assert len(sk_prf) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert len(M) <= 2**61 - 1 - 89
+  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), message=pk_seed + ADRS[:9] + M)[:16]
 
 
 #  Winternitz algorithms
 
 def wots_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The WOTS hash chain iteration function. Takes in a 16-byte hash `node` at a given `start` index
-  in a hash chain. This method iterates the hash chain by `steps` iterations, returning the hash
-  chain node at index `start+steps`. The `ADRS` must be prefilled to ensure the hashes are properly
-  tweaked.
+  The WOTS hash chain iteration function. Iterates the hash chain from index `start` by `steps`
+  steps, returning the node at index `start + steps`. The `ADRS` must be prefilled so the hashes
+  are correctly tweaked.
 
   - Inputs:
     - `node`: a 16-byte hash.
-    - `start`: an unsigned integer indicating the index of `node` in the hash chain.
-    - `steps`: an unsigned integer indicating how many steps to take up the hash chain.
+    - `start`: a 32-bit unsigned integer, the index of `node` in its hash chain.
+    - `steps`: a 32-bit unsigned integer, the number of steps to take up the chain; `start + steps` must not exceed `2**32`.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
-    - A 16-byte hash at index `start + steps`.
+    - a 16-byte hash at index `start + steps`.
 
-  This function is used very heavily by both stateful and stateless paths and is the core target
-  for optimization and parallelization.
+  This function is used in both stateful and stateless paths, and by both the signer and the verifier.
   """
+  assert len(node) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= start
+  assert 0 <= steps
+  assert start + steps <= 2 ** 32
   for j in range(start, start+steps):
     ADRS[18:22] = j.to_bytes(4)
     node = F(pk_seed, ADRS, node)
@@ -322,16 +357,20 @@ def wots_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: b
 
 def wots_tw_message_to_indexes(message: bytes) -> list[int]:
   """
-  The WOTS-TW message map function. Converts a 16-byte `message` to a checksummed array
-  of `WOTS_TW_CHAIN_COUNT` WOTS hash chain indexes in the range `[0, 2**WOTS_TW_CHAIN_BITS)`.
+  The WOTS-TW message map function. Converts a 16-byte `message` into a checksummed array of
+  `WOTS_TW_CHAIN_COUNT` chain indexes in `[0, 2**WOTS_TW_CHAIN_BITS)`.
 
   - Inputs:
-    - `message`: a 16-byte hash
+    - `message`: a 16-byte hash.
   - Output:
-    - An checksummed array of `WOTS_TW_CHAIN_BITS`-bit integers of length `WOTS_TW_CHAIN_COUNT`.
+    - a checksummed array of `WOTS_TW_CHAIN_COUNT` `WOTS_TW_CHAIN_BITS`-bit unsigned integers.
+
+  This function is only used in the stateless path, and by both the signer and the verifier.
   """
+  assert len(message) == 16
   msg_indexes = base_2b(message, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT1)
   checksum = WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)
+  assert 0 <= checksum <= WOTS_TW_CHECKSUM_MAX
 
   checksum_indexes = [0] * WOTS_TW_CHAIN_COUNT2
   for i in range(WOTS_TW_CHAIN_COUNT2):
@@ -345,28 +384,32 @@ def wots_tw_message_to_indexes_alt(message: bytes) -> list[int]:
   Alternative implementation, equivalent to `wots_tw_message_to_indexes` but using the
   more complex FIPS-205 algorithm.
   """
-  SPHX_WOTS_CHECKSUM_SHIFT = (8 - (WOTS_TW_CHAIN_BITS * WOTS_TW_CHAIN_COUNT2) % 8) % 8
-  SPHX_WOTS_CHECKSUM_BYTE_LEN = ceil(WOTS_TW_CHAIN_COUNT2 * WOTS_TW_CHAIN_BITS / 8)
+  assert len(message) == 16
+  checksum_shift = (8 - (WOTS_TW_CHAIN_BITS * WOTS_TW_CHAIN_COUNT2) % 8) % 8
+  checksum_byte_len = ceil(WOTS_TW_CHAIN_COUNT2 * WOTS_TW_CHAIN_BITS / 8)
   msg_indexes = base_2b(message, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT1)
-  checksum = (WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)) << SPHX_WOTS_CHECKSUM_SHIFT
-  checksum_bytes = checksum.to_bytes(SPHX_WOTS_CHECKSUM_BYTE_LEN)
+  checksum = (WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)) << checksum_shift
+  checksum_bytes = checksum.to_bytes(checksum_byte_len)
   checksum_indexes = base_2b(checksum_bytes, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT2)
   return msg_indexes + checksum_indexes
 
 def wots_tw_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The WOTS-TW public key generation function. Takes in the secret `sk_seed`, the `pk_seed`,
-  and an `ADRS`. The `ADRS` should be prefilled with the location of the WOTS keypair being used.
+  The WOTS-TW public key generation function. Computes the 16-byte WOTS-TW public key at the
+  keypair location prefilled in `ADRS`.
 
   - Inputs:
     - `sk_seed`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
-    - A 16-byte hash representing the WOTS-TW public key.
+    - a 16-byte hash representing the WOTS-TW public key.
 
-  This algorithm is used only by the signer.
+  This function is only used in the stateless path, and only by the signer.
   """
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   wots_pk = [b''] * WOTS_TW_CHAIN_COUNT
   for i in range(WOTS_TW_CHAIN_COUNT):
     ADRS[9] = SL_WOTS_TW_PRF
@@ -383,8 +426,8 @@ def wots_tw_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes
 
 def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The WOTS-TW signing function. Takes in a 16-byte `message`, the `sk_seed` and `pk_seed`,
-  and an `ADRS`. The `ADRS` should be prefilled with the location of the WOTS keypair being used.
+  The WOTS-TW signing function. Produces a WOTS-TW signature on a 16-byte `message`, at the keypair
+  location prefilled in `ADRS`.
 
   - Inputs:
     - `message`: a 16-byte message to sign.
@@ -392,10 +435,14 @@ def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
-    - A WOTS signature composed of `WOTS_TW_CHAIN_COUNT * 16` bytes.
+    - a `WOTS_TW_CHAIN_COUNT * 16`-byte signature.
 
-  This algorithm is used only by the signer.
+  This function is only used in the stateless path, and only by the signer.
   """
+  assert len(message) == 16
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   indexes = wots_tw_message_to_indexes(message)
   signature = [b''] * WOTS_TW_CHAIN_COUNT
   for i in range(WOTS_TW_CHAIN_COUNT):
@@ -409,20 +456,23 @@ def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray
 
 def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The WOTS-TW verification procedure. Recovers a WOTS-TW public key from a `signature` on a given
-  16-byte `message`. Takes in the `pk_seed`. The `ADRS` should be prefilled with the location of
-  the WOTS keypair being used.
+  The WOTS-TW verification function. Recovers a WOTS-TW public key from a `signature` on a 16-byte
+  `message`.
 
   - Inputs:
-    - `signature`: a string of `WOTS_TW_CHAIN_COUNT * 16` bytes.
+    - `signature`: a `WOTS_TW_CHAIN_COUNT * 16`-byte signature.
     - `message`: a 16-byte message.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
-    - A 16-byte hash representing the WOTS-TW public key.
+    - a 16-byte hash representing the WOTS-TW public key.
 
-  This algorithm is used by both signers and verifiers.
+  This function is only used in the stateless path, and by both the signer and the verifier.
   """
+  assert len(signature) == WOTS_TW_CHAIN_COUNT * 16
+  assert len(message) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   indexes = wots_tw_message_to_indexes(message)
   wots_pk = [b''] * WOTS_TW_CHAIN_COUNT
   ADRS[9] = SL_WOTS_TW_HASH
@@ -438,22 +488,22 @@ def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, AD
 
 def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: bytearray) -> tuple[int, list[int]]:
   """
-  The WOTS+C grinding function. Takes in a `message_digest`, the `pk_seed`, and an `ADRS`, and
-  grinds - up to a maximum of 2<sup>16</sup> attempts - until we find a counter that maps to a
-  constant sum index-set. Returns the lowest valid integer counter and the corresponding array
-  of constant-sum hash chain indexes. The `ADRS` should be prefilled with the location of the
-  WOTS+C key which will be used to sign the resulting indexes.
+  The WOTS+C grinding function. Grinds up to 2^16 counters until one maps `message_digest` to a
+  constant-sum index set, returning the lowest such counter and its index set.
 
   - Inputs:
     - `pk_seed`: a 16-byte salt.
     - `message_digest`: a 32-byte intermediate message digest (from `H_msg_sf`).
     - `ADRS`: a 22-byte address.
-  - Outputs:
-    - The smallest possible valid counter.
-    - The corresponding constant-sum set of hash chain indexes.
+  - Output:
+    - a tuple `(counter, indexes)`: the smallest valid 16-bit `counter` and the corresponding
+      constant-sum set of hash chain indexes (of length `WOTS_C_CHAIN_COUNT`).
 
-  This algorithm is used only by the signer.
+  This function is only used in the stateful path, and only by the signer.
   """
+  assert len(pk_seed) == 16
+  assert len(message_digest) == 32
+  assert len(ADRS) == 22
   ADRS[9] = SF_WOTS_C_GRIND
   for i in range(2**16):
     hashed = H_grind(pk_seed, ADRS, message_digest, i)
@@ -465,21 +515,23 @@ def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: by
 
 def wots_c_map_digest(pk_seed: bytes, message_digest: bytes, ADRS: bytearray, counter: int) -> Optional[list[int]]:
   """
-  The WOTS+C digest validation function. Takes in a `message_digest`, the `pk_seed`, an `ADRS`,
-  and a `counter` parsed from a WOTS+C signature. This evaluates the grinding counter and attempts
-  to map the digest to a constant sum set of hash chain indexes. If the `counter` is valid, this
-  function returns the constant sum index-set. Otherwise, it returns null.
+  The WOTS+C digest validation function. Evaluates a signature's grinding `counter` and returns the
+  constant-sum index set it yields, or null if the counter is invalid.
 
   - Inputs:
     - `pk_seed`: a 16-byte salt.
     - `message_digest`: a 32-byte intermediate message digest (from `H_msg_sf`).
     - `ADRS`: a 22-byte address.
-    - `counter`: an unsigned integer.
+    - `counter`: a 16-bit unsigned integer.
   - Output:
-    - A constant-sum set of hash chain indexes, or null.
+    - a constant-sum set of hash chain indexes (of length `WOTS_C_CHAIN_COUNT`), or null.
 
-  This algorithm is used only by the verifier.
+  This function is only used in the stateful path, and only by the verifier.
   """
+  assert len(pk_seed) == 16
+  assert len(message_digest) == 32
+  assert len(ADRS) == 22
+  assert 0 <= counter < 2**16
   ADRS[9] = SF_WOTS_C_GRIND
   hashed = H_grind(pk_seed, ADRS, message_digest, counter)
   indexes = base_2b(hashed, WOTS_C_CHAIN_BITS, WOTS_C_CHAIN_COUNT)
@@ -490,18 +542,21 @@ def wots_c_map_digest(pk_seed: bytes, message_digest: bytes, ADRS: bytearray, co
 
 def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The WOTS+C public key generation function. Takes in the secret `sk_seed`, the `pk_seed`, and an
-  `ADRS`. The `ADRS` should be prefilled with the location of the WOTS keypair being used.
+  The WOTS+C public key generation function. Computes the 16-byte WOTS+C public key at the keypair
+  location prefilled in `ADRS`.
 
   - Inputs:
     - `sk_seed`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
-    - A 16-byte hash representing the WOTS+C public key.
+    - a 16-byte hash representing the WOTS+C public key.
 
-  This algorithm is used only by the signer.
+  This function is only used in the stateful path, and only by the signer.
   """
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   wots_pk = [b''] * WOTS_C_CHAIN_COUNT
   ADRS[10:14] = zeros(4) # zeros reserved
   for i in range(WOTS_C_CHAIN_COUNT):
@@ -519,19 +574,23 @@ def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
 
 def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The WOTS+C signing function. Takes in a 32-byte `message_digest`, the `sk_seed` and `pk_seed`,
-  and an `ADRS`. The `ADRS` should be prefilled with the location of the WOTS keypair being used.
+  The WOTS+C signing function. Produces a WOTS+C signature on a 32-byte `message_digest`, at the
+  keypair location prefilled in `ADRS`.
 
   - Inputs:
     - `message_digest`: a 32-byte message digest to sign.
     - `sk_seed`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-  - Outputs:
-    - A WOTS signature composed of `2 + WOTS_C_CHAIN_COUNT * 16` bytes.
+  - Output:
+    - a `2 + WOTS_C_CHAIN_COUNT * 16`-byte signature.
 
-  This algorithm is used only by the signer.
+  This function is only used in the stateful path, and only by the signer.
   """
+  assert len(message_digest) == 32
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   counter, indexes = wots_c_grind_to_constant_sum(pk_seed, message_digest, ADRS)
   signature = [b''] * WOTS_C_CHAIN_COUNT
 
@@ -547,20 +606,23 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
 
 def wots_c_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes, ADRS: bytearray) -> Optional[bytes]:
   """
-  The WOTS+C verification procedure. Recovers a WOTS+C public key from a `signature` on a given
-  32-byte `message_digest`. Takes in the `pk_seed`, and an `ADRS`. The `ADRS`
-  should be prefilled with the location of the WOTS keypair being used.
+  The WOTS+C verification function. Recovers a WOTS+C public key from a `signature` on a 32-byte
+  `message_digest`.
 
   - Inputs:
-    - `signature`: a string of `2 + WOTS_C_CHAIN_COUNT * 16` bytes.
+    - `signature`: a `2 + WOTS_C_CHAIN_COUNT * 16`-byte signature.
     - `message_digest`: a 32-byte message digest.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
-    - A 16-byte hash representing the WOTS+C public key, or null.
+    - a 16-byte hash representing the WOTS+C public key, or null.
 
-  This algorithm is used only by the verifier.
+  This function is only used in the stateful path, and only by the verifier.
   """
+  assert len(signature) == 2 + WOTS_C_CHAIN_COUNT * 16
+  assert len(message_digest) == 32
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   counter = int.from_bytes(signature[0:2])
   indexes = wots_c_map_digest(pk_seed, message_digest, ADRS, counter)
 
@@ -586,33 +648,37 @@ def wots_c_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: byt
 
 def xmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The XMSS internal node computation helper function. This is a recursive function which takes
-  in the `sk_seed`, a target `node_index`, a `node_height`, the `pk_seed`, and an `ADRS`.
-  The `ADRS` must be prefilled with the location of the XMSS tree in the hypertree to ensure
-  the hashes are properly tweaked.
+  The XMSS internal node computation function. Recursively computes the XMSS node at the given
+  `node_index` and `node_height`. The `ADRS` must be prefilled with the location of the XMSS tree
+  in the hypertree to ensure the hashes are properly tweaked.
 
   - Inputs:
     - `sk_seed`: a 16-byte secret.
-    - `node_index`: An unsigned integer indicating the index (from the left) of the desired node in the XMSS layer.
-    - `node_height`: An unsigned integer indicating the height (from the bottom) of the desired node in the XMSS layer.
+    - `node_index`: a 32-bit unsigned integer, the index (from the left) of the node in the XMSS layer.
+    - `node_height`: a 32-bit unsigned integer, the height (from the bottom) of the node in the XMSS layer.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-  - Outputs:
-    - A 16-byte XMSS node hash
+  - Output:
+    - a 16-byte XMSS node hash.
 
-  This algorithm is used only by the signer.
+  This function is only used in the stateless path, and only by the signer.
   """
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= node_index < 2**32
+  assert 0 <= node_height < 2**32
   if node_height == 0: # Bottom layer: return the WOTS-TW pubkey hash.
     ADRS[10:14] = node_index.to_bytes(4)
     return wots_tw_pubkey_gen(sk_seed, pk_seed, ADRS)
 
-  # Recursively derive the left/right child nodes
+  # Recursively derive the left/right child nodes.
   lchild_index = 2 * node_index
   child_height = node_height - 1
   lchild = xmss_node(sk_seed, lchild_index, child_height, pk_seed, ADRS)
   rchild = xmss_node(sk_seed, lchild_index + 1, child_height, pk_seed, ADRS)
 
-  # Compute & return the parent node.
+  # Compute and return the parent node.
   ADRS[9] = SL_XMSS_TREE
   ADRS[10:14] = zeros(4)
   ADRS[14:18] = node_height.to_bytes(4)
@@ -621,28 +687,31 @@ def xmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes,
 
 def xmss_sign(message: bytes, sk_seed: bytes, keypair_index: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The XMSS signing procedure. This function produces a deterministic WOTS-TW signature using a
-  specific leaf of a XMSS tree, and appends a merkle authentication path to form a XMSS
-  signature. Takes in the `message` to sign, the `sk_seed`, the `keypair_index` to sign with,
-  the `pk_seed`, and an `ADRS`. The `ADRS` must be prefilled with the location of the XMSS tree
-  in the hypertree to ensure the hashes are properly tweaked.
+  The XMSS signing function. Produces a deterministic WOTS-TW signature at leaf `keypair_index` and
+  appends the Merkle authentication path to form an XMSS signature. The `ADRS` must be prefilled with
+  the location of the XMSS tree in the hypertree to ensure the hashes are properly tweaked.
 
   - Inputs:
     - `message`: a 16-byte message to sign.
     - `sk_seed`: a 16-byte secret.
-    - `keypair_index`: The index of the WOTS-TW keypair to sign with.
+    - `keypair_index`: a 32-bit unsigned integer, the index of the WOTS-TW keypair to sign with.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-  - Outputs:
-    - A XMSS signature consisting of `16 * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)` bytes.
+  - Output:
+    - a `16 * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)`-byte signature.
 
-  This algorithm is used only by the signer.
+  This function is only used in the stateless path, and only by the signer.
   """
-  # Sign the message with WOTS-TW
+  assert len(message) == 16
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= keypair_index < 2**32
+  # Sign the message with WOTS-TW.
   ADRS[10:14] = keypair_index.to_bytes(4)
   sig = wots_tw_sign(message, sk_seed, pk_seed, ADRS)
 
-  # Append the Merkle authentication path
+  # Append the Merkle authentication path.
   for j in range(SPHX_XMSS_HEIGHT):
     sibling_index = (keypair_index >> j) ^ 1
     sig += xmss_node(sk_seed, sibling_index, j, pk_seed, ADRS)
@@ -651,22 +720,26 @@ def xmss_sign(message: bytes, sk_seed: bytes, keypair_index: int, pk_seed: bytes
 
 def xmss_pubkey_from_sig(keypair_index: int, signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The XMSS verification function. Recovers an XMSS public key from a `signature` on a given
-  16-byte `message`. Takes in the `pk_seed`, and an `ADRS`. The exact position of the WOTS-TW
-  signing leaf is given by the `keypair_index` argument. The `ADRS` must be prefilled with the
-  location of the XMSS tree in the hypertree to ensure the hashes are properly tweaked.
+  The XMSS verification function. Recovers an XMSS root from a `signature` on a 16-byte `message`
+  at leaf `keypair_index`. The `ADRS` must be prefilled with the location of the XMSS tree in the
+  hypertree to ensure the hashes are properly tweaked.
 
   - Inputs:
     - `keypair_index`: a 32-bit unsigned integer, the index of the WOTS-TW keypair to sign with.
-    - `signature`: an XMSS signature consisting of `16 * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)` bytes.
+    - `signature`: a `16 * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)`-byte signature.
     - `message`: a 16-byte message.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
-    - a 16-byte XMSS root node hash
+    - a 16-byte XMSS root node hash.
 
-  This algorithm is used both by the signer and the verifier.
+  This function is only used in the stateless path, and by both the signer and the verifier.
   """
+  assert len(signature) == 16 * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)
+  assert len(message) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= keypair_index < 2**32
   wots_sig = signature[0 : WOTS_TW_CHAIN_COUNT*16]
   xmss_auth = signature[WOTS_TW_CHAIN_COUNT*16 : (WOTS_TW_CHAIN_COUNT+SPHX_XMSS_HEIGHT)*16]
 
@@ -688,26 +761,28 @@ def xmss_pubkey_from_sig(keypair_index: int, signature: bytes, message: bytes, p
   return node
 
 
-#  Hypertree Algorithms
+#  Hypertree algorithms
 
 def hypertree_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, tree_index: int, leaf_index: int) -> bytes:
   """
-  The hypertree signing function. Signs a 16-byte `message`, using a hypertree of XMSS trees. Takes
-  in the `sk_seed`, `pk_seed`, the index of the bottom-layer XMSS tree `tree_index`, and the index
-  of the WOTS-TW leaf key within that tree `leaf_index`.
+  The hypertree signing function. Signs a 16-byte `message` through a hypertree of XMSS trees.
 
   - Inputs:
     - `message`: a 16-byte message to sign.
     - `sk_seed`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
-    - `tree_index`: the index (from the left) of the bottom-layer XMSS tree to sign with.
-    - `leaf_index`: the index (from the left) of the WOTS-TW key in the bottom-layer XMSS tree to sign with.
+    - `tree_index`: a 64-bit unsigned integer, the index (from the left) of the bottom-layer XMSS tree to sign with.
+    - `leaf_index`: a 32-bit unsigned integer, the index (from the left) of the WOTS-TW key in the bottom-layer XMSS tree to sign with.
   - Output:
-    - A hypertree signature, a byte string of length
-      `16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)`
+    - a `16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)`-byte signature.
 
   This function is only used in the stateless path, and only by the signer.
   """
+  assert len(message) == 16
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert 0 <= tree_index < 2**64
+  assert 0 <= leaf_index < 2**32
   ADRS = bytearray(22)
 
   sig = b""
@@ -725,21 +800,27 @@ def hypertree_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, tree_index: i
 
 def hypertree_verify(message: bytes, signature: bytes, pk_seed: bytes, tree_index: int, leaf_index: int, sl_root: bytes) -> bool:
   """
-  The hypertree verification procedure. Recovers the root of a hypertree from a hypertree
-  `signature`, and compares it against the given `sl_root` hash.
+  The hypertree verification function. Recovers the hypertree root from a `signature` and compares
+  it against `sl_root`.
 
   - Inputs:
-    - `message`: a 16-byte message to sign.
-    - `signature`: a `16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)` hypertree signature.
+    - `message`: a 16-byte message.
+    - `signature`: a `16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)`-byte signature.
     - `pk_seed`: a 16-byte salt.
-    - `tree_index`: the index (from the left) of the bottom-layer XMSS tree to sign with.
-    - `leaf_index`: the index (from the left) of the WOTS-TW key in the bottom-layer XMSS tree to sign with.
-    - `sl_root`: the 16-byte stateless root hash from the SHRINCS public key.
+    - `tree_index`: a 64-bit unsigned integer, the index (from the left) of the bottom-layer XMSS tree to sign with.
+    - `leaf_index`: a 32-bit unsigned integer, the index (from the left) of the WOTS-TW key in the bottom-layer XMSS tree to sign with.
+    - `sl_root`: the 16-byte root hash of the stateless root tree.
   - Output:
-    - A boolean indicating if the signature is valid.
+    - a boolean indicating if the signature is valid.
 
   This function is only used in the stateless path, and only by the verifier.
   """
+  assert len(message) == 16
+  assert len(signature) == 16 * SPHX_LAYER_COUNT * (SPHX_XMSS_HEIGHT + WOTS_TW_CHAIN_COUNT)
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert 0 <= tree_index < 2**64
+  assert 0 <= leaf_index < 2**32
   ADRS = bytearray(22)
 
   offset = 0
@@ -759,22 +840,27 @@ def hypertree_verify(message: bytes, signature: bytes, pk_seed: bytes, tree_inde
 
 def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, structure: bytes, ADRS: bytearray) -> bytes:
   """
-  The FXMSS internal node computation helper function. This is a recursive function which takes
-  in the `sk_seed`, a target `node_index`, a `node_height`, the `pk_seed`, an FXMSS tree
-  `structure` identifier, and an `ADRS`.
+  The FXMSS internal node computation function. Recursively computes the FXMSS node at the given
+  `node_index` and `node_height` for the tree `structure`.
 
   - Inputs:
     - `sk_seed`: a 16-byte secret.
-    - `node_index`: A 64-bit unsigned integer indicating the index (from the left) of the desired node in the FXMSS layer.
-    - `node_height`: An 8-bit unsigned integer indicating the height (from the bottom) of the desired node in the FXMSS tree.
+    - `node_index`: a 64-bit unsigned integer, the index (from the left) of the node in the FXMSS layer.
+    - `node_height`: an 8-bit unsigned integer, the height (from the bottom) of the node in the FXMSS tree.
     - `pk_seed`: a 16-byte salt.
     - `structure`: a 2-byte identifier describing the FXMSS tree structure.
     - `ADRS`: a 22-byte address.
-  - Outputs:
-    - A 16-byte FXMSS node hash
+  - Output:
+    - a 16-byte FXMSS node hash.
 
-  This algorithm is used only by the signer.
+  This function is only used in the stateful path, and only by the signer.
   """
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(structure) == 2
+  assert len(ADRS) == 22
+  assert 0 <= node_index < 2**64
+  assert 0 <= node_height < 2**8
   node_depth = FXMSS_HEIGHT - node_height
   tree_shape, tree_depth = structure[0], structure[1]
 
@@ -786,19 +872,19 @@ def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes
     ADRS[1:9] = node_index.to_bytes(8)
     return wots_c_pubkey_gen(sk_seed, pk_seed, ADRS)
 
-  # Catch and throw if control would enter an infinite resursive loop.
+  # Catch and throw if control would enter an infinite recursive loop.
   if tree_shape == FXMSS_SHAPE_UNBALANCED:
     assert node_index == 0
   elif tree_shape == FXMSS_SHAPE_BALANCED:
     assert node_depth < tree_depth
 
-  # Recursively derive the left/right child nodes
+  # Recursively derive the left/right child nodes.
   lchild_index = 2 * node_index
   child_height = node_height - 1
   lchild = fxmss_node(sk_seed, lchild_index, child_height, pk_seed, structure, ADRS)
   rchild = fxmss_node(sk_seed, lchild_index + 1, child_height, pk_seed, structure, ADRS)
 
-  # Compute & return the parent node.
+  # Compute and return the parent node.
   ADRS[0] = node_height
   ADRS[1:9] = node_index.to_bytes(8)
   ADRS[9] = SF_FXMSS_TREE
@@ -807,23 +893,27 @@ def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes
 
 def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_height: int, pk_seed: bytes, structure: bytes) -> bytes:
   """
-  The FXMSS signing procedure. This function produces a deterministic WOTS+C signature using a
-  specific leaf of an FXMSS tree, and appends a merkle authentication path to form an FXMSS
-  signature. Takes in a `message_digest` to sign, the `sk_seed`, the WOTS+C leaf position
-  described by `leaf_index` and `leaf_height`, the `pk_seed`, and the tree `structure`.
+  The FXMSS signing function. Produces a deterministic WOTS+C signature at the leaf given by
+  `leaf_index`/`leaf_height` and appends the Merkle authentication path to form an FXMSS signature.
 
   - Inputs:
     - `message_digest`: a 32-byte message digest.
     - `sk_seed`: a 16-byte secret.
-    - `leaf_index`: A 64-bit unsigned integer indicating the index (from the left) of the signing leaf in the FXMSS layer.
-    - `leaf_height`: An 8-bit unsigned integer indicating the height (from the bottom) of the signing leaf in the FXMSS tree.
+    - `leaf_index`: a 64-bit unsigned integer, the index (from the left) of the signing leaf in the FXMSS layer.
+    - `leaf_height`: an 8-bit unsigned integer, the height (from the bottom) of the signing leaf in the FXMSS tree.
     - `pk_seed`: a 16-byte salt.
     - `structure`: a 2-byte identifier describing the FXMSS tree structure.
-  - Outputs:
-    - An FXMSS signature, a byte string with length `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT - leaf_height)`
+  - Output:
+    - a `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT - leaf_height)`-byte signature.
 
-  This algorithm is used only by the signer.
+  This function is only used in the stateful path, and only by the signer.
   """
+  assert len(message_digest) == 32
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(structure) == 2
+  assert 0 <= leaf_index < 2**64
+  assert 0 <= leaf_height < 2**8
   leaf_depth = FXMSS_HEIGHT - leaf_height
 
   # Validate the leaf is positioned correctly for the specified tree structure.
@@ -838,7 +928,7 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
   ADRS[1:9] = leaf_index.to_bytes(8)
   sig = wots_c_sign(message_digest, sk_seed, pk_seed, ADRS)
 
-  # Append the Merkle authentication path
+  # Append the Merkle authentication path.
   for j in range(leaf_depth):
     sibling_index = (leaf_index >> j) ^ 1
     sibling_height = leaf_height + j
@@ -846,39 +936,40 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
 
   return sig
 
-def fxmss_pubkey_from_sig(node_index: int, signature: bytes, message_digest: bytes, pk_seed: bytes) -> Optional[bytes]:
+def fxmss_pubkey_from_sig(leaf_index: int, signature: bytes, message_digest: bytes, pk_seed: bytes) -> Optional[bytes]:
   """
-  The FXMSS verification function. Recovers an FXMSS public key from a `signature` on a given
-  32-byte `message_digest`. Takes in the `pk_seed`.
-
-  The length of the `signature` implies the depth of the WOTS+C signing leaf. The exact
-  left/right position of the WOTS+C signing leaf within its layer is given explicitly by the
-  `node_index` argument.
+  The FXMSS verification function. Recovers an FXMSS root from a `signature` on a 32-byte
+  `message_digest`. The signature length implies the leaf depth; `leaf_index` gives its
+  left-to-right position.
 
   - Inputs:
-    - `node_index`: a 64-bit unsigned integer.
-    - `signature`: a variable-length FXMSS signature.
-      - Must be at least `2 + 16 * (WOTS_C_CHAIN_COUNT + 1)` bytes long.
-      - Must be no longer than `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT)` bytes long.
-      - Byte length must be 2 more than a multiple of 16.
+    - `leaf_index`: a 64-bit unsigned integer, the left-to-right position of the WOTS+C signing leaf.
+    - `signature`: a variable-length signature of `2 + 16 * (WOTS_C_CHAIN_COUNT + 1)` to `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT)` bytes, with length 2 more than a multiple of 16.
     - `message_digest`: a 32-byte message digest.
     - `pk_seed`: a 16-byte salt.
   - Output:
-    - a 16-byte FXMSS root node hash, or null
+    - a 16-byte FXMSS root node hash, or null.
+
+  This function is only used in the stateful path, and only by the verifier.
   """
+  assert len(message_digest) == 32
+  assert len(pk_seed) == 16
+  assert 2 + 16 * WOTS_C_CHAIN_COUNT <= len(signature) <= 2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT)
+  assert len(signature) % 16 == 2
+  assert 0 <= leaf_index < 2**64
   wots_sig = signature[0 : 2+WOTS_C_CHAIN_COUNT*16]
   xmss_auth = signature[2+WOTS_C_CHAIN_COUNT*16 : len(signature)]
 
-  node_depth = floor(len(xmss_auth) / 16)
+  leaf_depth = floor(len(xmss_auth) / 16)
 
-  # Ensure node_index describes a valid position in the FXMSS tree.
-  assert node_index < 2 ** min(64, node_depth)
+  # Ensure leaf_index describes a valid position in the FXMSS tree.
+  assert leaf_index < 2 ** min(64, leaf_depth)
 
-  node_height = FXMSS_HEIGHT - node_depth
+  leaf_height = FXMSS_HEIGHT - leaf_depth
 
   ADRS = bytearray(22)
-  ADRS[0] = node_height
-  ADRS[1:9] = node_index.to_bytes(8)
+  ADRS[0] = leaf_height
+  ADRS[1:9] = leaf_index.to_bytes(8)
   node = wots_c_pubkey_from_sig(wots_sig, message_digest, pk_seed, ADRS)
   if node is None:
     return None
@@ -886,11 +977,11 @@ def fxmss_pubkey_from_sig(node_index: int, signature: bytes, message_digest: byt
   ADRS[9] = SF_FXMSS_TREE
   ADRS[10:22] = zeros(12)
 
-  for k in range(node_depth):
+  for k in range(leaf_depth):
     ADRS[0] += 1
-    ADRS[1:9] = (node_index >> (k+1)).to_bytes(8)
+    ADRS[1:9] = (leaf_index >> (k+1)).to_bytes(8)
     sibling = xmss_auth[k*16 : (k+1)*16]
-    if (node_index >> k) & 1 == 1:
+    if (leaf_index >> k) & 1 == 1:
       node = H(pk_seed, ADRS, sibling + node)
     else:
       node = H(pk_seed, ADRS, node + sibling)
@@ -900,47 +991,48 @@ def fxmss_pubkey_from_sig(node_index: int, signature: bytes, message_digest: byt
 
 #  FORS algorithms
 
-def fors_sk_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray, tree_index: int) -> bytes:
+def fors_sk_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray, node_index: int) -> bytes:
   """
-  The FORS secret preimage generation function. Generates a secret 16-byte preimage from `sk_seed`.
-  Takes in `pk_seed`, an `ADRS`, and the `tree_index` to indicate the position of the FORS leaf
-  in the forest. The `ADRS` must be prefilled with the location of the FORS keypair to ensure
-  the hashes are properly tweaked.
-
+  The FORS secret preimage generation function. Generates the secret 16-byte preimage of the FORS
+  leaf at forest-wide index `node_index`. The `ADRS` must be prefilled with the location of the FORS
+  keypair to ensure the hashes are properly tweaked.
 
   - Inputs:
     - `sk_seed`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-    - `tree_index`: a 32-bit unsigned integer.
+    - `node_index`: a 32-bit unsigned integer, a forest-wide leaf index in `[0, SPHX_FORS_COUNT * 2**SPHX_FORS_HEIGHT)`.
   - Output:
-    - A 16-byte preimage.
+    - a 16-byte preimage.
 
   This function is only used in the stateless path, and only by the signer.
 
-  Note the `tree_index` of a FORS leaf or node is _indexed across the entire forest,_ not just
+  Note the `node_index` of a FORS leaf or node is _indexed across the entire forest,_ not just
   within a single tree. The index of leaf `l` in tree `t` is `t * 2**SPHX_FORS_HEIGHT + l`.
   """
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= node_index < SPHX_FORS_COUNT * 2**SPHX_FORS_HEIGHT
   ADRS[9] = SL_FORS_PRF
   ADRS[14:18] = zeros(4)
-  ADRS[18:22] = tree_index.to_bytes(4)
+  ADRS[18:22] = node_index.to_bytes(4)
   return PRF(pk_seed, sk_seed, ADRS)
 
 def fors_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The FORS internal merkle node computation helper function. This is a recursive function which
-  takes in the `sk_seed`, `pk_seed`, an `ADRS`, and integers `node_height`, `node_index` which
-  describe the position of the FORS node in the forest of merkle trees. The `ADRS` must be
-  prefilled with the location of the FORS keypair to ensure the hashes are properly tweaked.
+  The FORS internal node computation function. Recursively computes the FORS node at the forest-wide
+  `node_index` and `node_height`. The `ADRS` must be prefilled with the location of the FORS keypair
+  to ensure the hashes are properly tweaked.
 
   - Inputs:
     - `sk_seed`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
-    - `node_index`: a 32-bit unsigned integer.
-    - `node_height`: a 32-bit unsigned integer.
+    - `node_index`: a 32-bit unsigned integer, a forest-wide node index in `[0, SPHX_FORS_COUNT * 2**(SPHX_FORS_HEIGHT - node_height))`.
+    - `node_height`: a 32-bit unsigned integer, a node height in `[0, SPHX_FORS_HEIGHT]`.
   - Output:
-    - A 16-byte FORS node hash.
+    - a 16-byte FORS node hash.
 
   This function is only used in the stateless path, and only by the signer.
 
@@ -948,6 +1040,11 @@ def fors_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes,
   within a single tree. The index of node `l` in tree `t` at height `h` is
   `t * 2**(SPHX_FORS_HEIGHT - h) + l`.
   """
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
+  assert 0 <= node_height <= SPHX_FORS_HEIGHT
+  assert 0 <= node_index < SPHX_FORS_COUNT * 2**(SPHX_FORS_HEIGHT - node_height)
   if node_height == 0:
     preimage = fors_sk_gen(sk_seed, pk_seed, ADRS, node_index)
     ADRS[9] = SL_FORS_TREE
@@ -967,21 +1064,23 @@ def fors_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes,
 
 def fors_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The FORS signing function. Signs a `message_digest`, using `sk_seed` and `pk_seed`, with the
-  location of the FORS leaf specified in `ADRS`. The `ADRS` must be prefilled with the location
-  of the FORS keypair to ensure the hashes are properly tweaked.
+  The FORS signing function. Produces a FORS signature on a `message_digest`. The `ADRS` must be
+  prefilled with the location of the FORS keypair to ensure the hashes are properly tweaked.
 
   - Inputs:
-    - `message_digest`: a digest of a message to sign.
-      - Must be exactly `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)` bytes long.
+    - `message_digest`: a `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)`-byte message digest.
     - `sk_seed`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
-    - A FORS signature, a byte string of length `16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)`.
+    - a `16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)`-byte signature.
 
   This function is only used in the stateless path, and only by the signer.
   """
+  assert len(message_digest) == ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)
+  assert len(sk_seed) == 16
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   sig = b""
   index_set = base_2b(message_digest, SPHX_FORS_HEIGHT, SPHX_FORS_COUNT)
   for i in range(SPHX_FORS_COUNT):
@@ -994,21 +1093,24 @@ def fors_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytea
 
 def fors_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The FORS verification procedure. Recovers a FORS public key hash from the given `signature` on a
-  `message_digest`. Takes in a `pk_seed` and `ADRS`. The `ADRS` must be prefilled with the location
-  of the FORS keypair to ensure the hashes are properly tweaked.
+  The FORS verification function. Recovers a FORS public key from a `signature` on a
+  `message_digest`. The `ADRS` must be prefilled with the location of the FORS keypair to ensure
+  the hashes are properly tweaked.
 
   - Inputs:
-    - `signature`: a byte string of length `16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)`.
-    - `message_digest`: a digest of a message to sign.
-      - Must be exactly `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)` bytes long.
+    - `signature`: a `16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)`-byte signature.
+    - `message_digest`: a `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)`-byte message digest.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
-    - A 16-byte hash of the FORS public key.
+    - a 16-byte hash of the FORS public key.
 
-  This function is only used in the stateless path.
+  This function is only used in the stateless path, and by both the signer and the verifier.
   """
+  assert len(signature) == 16 * SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1)
+  assert len(message_digest) == ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)
+  assert len(pk_seed) == 16
+  assert len(ADRS) == 22
   index_set = base_2b(message_digest, SPHX_FORS_HEIGHT, SPHX_FORS_COUNT)
 
   offset = 0
@@ -1044,23 +1146,25 @@ def fors_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes
 
 def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: bytes) -> Tuple[bytes, int, int]:
   """
-  The SLH-DSA message hashing function. Derives a FORS message digest, tree index, and FORS leaf index
-  by hashing a randomizer `R`, `pk_seed`, `sl_root`, and `message`. This is an internal helper
-  function which partitions and parses the output of `H_msg_sl` into the pseudorandom digest outputs
-  needed for SLH-DSA signing and verification.
+  The SLH-DSA message hashing function. Derives the FORS message digest, bottom-layer XMSS tree
+  index, and FORS leaf index from `message` under `H_msg_sl`.
 
   - Inputs:
     - `R`: a 16-byte randomizer.
     - `pk_seed`: a 16-byte salt.
     - `sl_root`: the 16-byte root hash of the stateless root tree.
-    - `message`: an arbitrary-length byte string.
+    - `message`: a message of at most `2**61 - 1 - 48` bytes.
   - Outputs:
     - a `ceil(SPHX_FORS_COUNT * SPHX_FORS_HEIGHT / 8)`-byte message digest, ready for use by FORS.
-    - a pseudorandomly selected index of a bottom-layer XMSS tree (less than `2**(SPHX_XMSS_HEIGHT * (SPHX_LAYER_COUNT - 1))`).
-    - a pseudorandomly selected index of a FORS key within an XMSS tree (less than `2**SPHX_XMSS_HEIGHT`).
+    - a pseudorandomly selected index of a bottom-layer XMSS tree, in `[0, 2**(SPHX_XMSS_HEIGHT * (SPHX_LAYER_COUNT - 1)))`.
+    - a pseudorandomly selected index of a FORS key within an XMSS tree, in `[0, 2**SPHX_XMSS_HEIGHT)`.
 
-  This function is used only in the stateless path, by both signer and verifier.
+  This function is only used in the stateless path, and by both the signer and the verifier.
   """
+  assert len(R) == 16
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert len(message) <= 2**61 - 1 - 48
   digest = H_msg_sl(R, pk_seed, sl_root, message)
 
   fors_digest = digest[:ceil(SPHX_FORS_HEIGHT * SPHX_FORS_COUNT / 8)]
@@ -1078,9 +1182,9 @@ def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: by
 
 def slh_dsa_sign_internal(message: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed: bytes, sl_root: bytes, opt_rand: Optional[bytes]) -> bytes:
   """
-  The SLH-DSA internal signing function. Signs a given `message` with `sk_seed`, using `pk_seed` to
-  salt all hash function invocations, using `sk_prf` and `opt_rand` to generate an unpredictable
-  randomizer, and binds the signature to the given `sl_root`.
+  The SLH-DSA internal signing function. Signs `message` with `sk_seed`, salting all hashes with
+  `pk_seed`, deriving the randomizer from `sk_prf`/`opt_rand`, and binding the signature to
+  `sl_root`.
 
   The optional additional data `opt_rand` is used to further salt the randomizer. If omitted,
   the algorithm uses `pk_seed` in its place, resulting in the _deterministic variant_ of SLH-DSA.
@@ -1089,18 +1193,23 @@ def slh_dsa_sign_internal(message: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed
   hypertree signature, all concatenated together.
 
   - Inputs:
-    - `message`: an arbitrary-length byte string.
+    - `message`: a message of at most `2**61 - 1 - 80` bytes.
     - `sk_seed`: a 16-byte secret.
     - `sk_prf`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
     - `sl_root`: the 16-byte root hash of the stateless root tree.
-    - `opt_rand`: (optional) a 16-byte string used to salt the randomizer.
+    - `opt_rand`: an optional 16-byte salt for the randomizer.
   - Output:
-    - An SLH-DSA signature, of length
-    `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`
+    - a `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`-byte signature.
 
   This function is only used in the stateless path, and only by the signer.
   """
+  assert len(sk_seed) == 16
+  assert len(sk_prf) == 16
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert opt_rand is None or len(opt_rand) == 16
+  assert len(message) <= 2**61 - 1 - 80
   if opt_rand is None:
     opt_rand = pk_seed # deterministic mode
 
@@ -1119,20 +1228,22 @@ def slh_dsa_sign_internal(message: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed
 
 def slh_dsa_verify_internal(message: bytes, signature: bytes, pk_seed: bytes, sl_root: bytes) -> bool:
   """
-  The SLH-DSA internal verification procedure. Recovers the root hash of the root tree from a
-  `signature` on a given `message`, and checks it against `sl_root`.
+  The SLH-DSA internal verification function. Recovers the root-tree root from a `signature` on
+  `message` and checks it against `sl_root`.
 
   - Inputs:
-    - `message`: an arbitrary-length byte string.
-    - `signature`: an SLH-DSA signature of length
-      `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`
+    - `message`: a message of at most `2**61 - 1 - 80` bytes.
+    - `signature`: a `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`-byte signature.
     - `pk_seed`: a 16-byte salt.
     - `sl_root`: the 16-byte root hash of the stateless root tree.
   - Output:
-    - A boolean indicating if the signature is valid.
+    - a boolean indicating if the signature is valid.
 
   This function is only used in the stateless path, and only by the verifier.
   """
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert len(message) <= 2**61 - 1 - 80
   if len(signature) != 16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)):
     return False
 
@@ -1152,54 +1263,59 @@ def slh_dsa_verify_internal(message: bytes, signature: bytes, pk_seed: bytes, sl
 
 def slh_dsa_sign(message: bytes, ctx: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed: bytes, sl_root: bytes, opt_rand: Optional[bytes]) -> bytes:
   """
-  The SLH-DSA external signing function. Signs a given `message` with `sk_seed`, using `pk_seed` to
-  salt all hash function invocations, using `sk_prf` and `opt_rand` to generate an unpredictable
-  randomizer, and binds the signature to the given `sl_root`.
+  The SLH-DSA external signing function. Signs `message` with `sk_seed`, prepending the context
+  `ctx`; salts all hashes with `pk_seed`, derives the randomizer from `sk_prf`/`opt_rand`, and
+  binds to `sl_root`.
 
   - Inputs:
-    - `message`: an arbitrary-length byte string.
-    - `ctx`: a variable-length context byte string.
-      - Must be at most 255 bytes long.
+    - `message`: a message of at most `2**61 - 1 - 82 - len(ctx)` bytes.
+    - `ctx`: a context of at most 255 bytes.
     - `sk_seed`: a 16-byte secret.
     - `sk_prf`: a 16-byte secret.
     - `pk_seed`: a 16-byte salt.
     - `sl_root`: the 16-byte root hash of the stateless root tree.
-    - `opt_rand`: (optional) a 16-byte string used to salt the randomizer.
+    - `opt_rand`: an optional 16-byte salt for the randomizer.
   - Output:
-    - An SLH-DSA signature, of length
-    `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`
+    - a `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`-byte signature.
 
   This function is only used in the stateless path, and only by the signer.
 
-  This is a simple wrapper around `slh_dsa_sign_internal` which prepends an optional context string
-  `ctx` to every message. Verifiers must use `slh_dsa_verify` with the same `ctx` string.
+  This is a simple wrapper around `slh_dsa_sign_internal` which prepends an optional context
+  `ctx` to every message. Verifiers must use `slh_dsa_verify` with the same `ctx`.
   """
   assert len(ctx) < 256
+  assert len(sk_seed) == 16
+  assert len(sk_prf) == 16
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert opt_rand is None or len(opt_rand) == 16
+  assert len(message) <= 2**61 - 1 - 82 - len(ctx)
   contextualized_msg = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + message
   return slh_dsa_sign_internal(contextualized_msg, sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
 
 def slh_dsa_verify(message: bytes, signature: bytes, ctx: bytes, pk_seed: bytes, sl_root: bytes) -> bool:
   """
-  The SLH-DSA verification procedure. Recovers the root hash of the root tree from a `signature`
-  on a given `message`, and checks it against `sl_root`.
+  The SLH-DSA verification function. Recovers the root-tree root from a `signature` on `message`
+  (with context `ctx`) and checks it against `sl_root`.
 
   - Inputs:
-    - `message`: an arbitrary-length byte string.
-    - `signature`: an SLH-DSA signature of length
-      `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`
-    - `ctx`: a variable-length context byte string.
-      - Must be at most 255 bytes long.
+    - `message`: a message of at most `2**61 - 1 - 82 - len(ctx)` bytes.
+    - `signature`: a `16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT))`-byte signature.
+    - `ctx`: a context of at most 255 bytes.
     - `pk_seed`: a 16-byte salt.
     - `sl_root`: the 16-byte root hash of the stateless root tree.
   - Output:
-    - A boolean indicating if the signature is valid.
+    - a boolean indicating if the signature is valid.
 
   This function is only used in the stateless path, and only by the verifier.
 
-  This is a simple wrapper around `slh_dsa_verify_internal` which prepends an optional context string
-  `ctx` to every message. Signatures must use be produced via `slh_dsa_sign` with the same `ctx` string.
+  This is a simple wrapper around `slh_dsa_verify_internal` which prepends an optional context
+  `ctx` to every message. Signatures must be produced via `slh_dsa_sign` with the same `ctx`.
   """
   assert len(ctx) < 256
+  assert len(pk_seed) == 16
+  assert len(sl_root) == 16
+  assert len(message) <= 2**61 - 1 - 82 - len(ctx)
   contextualized_msg = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + message
   return slh_dsa_verify_internal(contextualized_msg, signature, pk_seed, sl_root)
 
@@ -1208,15 +1324,17 @@ def slh_dsa_verify(message: bytes, signature: bytes, ctx: bytes, pk_seed: bytes,
 
 def shrincs_keygen(seed: bytes, sf_structure: bytes) -> Tuple[bytes, bytes]:
   """
-  The SHRINCS key-generation procedure. Computes secret and public keys from a given 48-byte `seed`
-  and the `sf_structure` of the stateful FXMSS tree.
+  The SHRINCS key generation function. Computes the secret and public keys from a 48-byte `seed`
+  and the stateful tree `sf_structure`.
 
   - Inputs:
     - `seed`: a 48-byte random seed. Must be sampled from a CSRNG.
     - `sf_structure`: a 2-byte identifier describing the shape and depth of the stateful FXMSS tree.
   - Outputs:
-    - the SHRINCS secret key, of length 82 bytes.
-    - the SHRINCS public key, of length 48 bytes.
+    - an 82-byte SHRINCS secret key.
+    - a 48-byte SHRINCS public key.
+
+  This function is used only during key generation.
 
   > [!WARNING]
   > The `sf_structure` argument must come from a trusted source or else be validated.
@@ -1241,23 +1359,23 @@ def shrincs_keygen(seed: bytes, sf_structure: bytes) -> Tuple[bytes, bytes]:
 
 def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[Tuple[int, int]]:
   """
-  The SHRINCS stateful path leaf selection algorithm. Given an FXMSS tree `structure` and the
-  current `state_ctr` counter, this function computes the position of the next WOTS+C leaf in
-  the FXMSS tree, returned as a tuple of `(index, height)` integers.
+  The SHRINCS stateful-path leaf-selection function. Computes the position `(index, height)` of the
+  next WOTS+C leaf for the given `structure` and `state_ctr`.
 
   - Inputs:
     - `structure`: a 2-byte identifier describing the FXMSS tree structure.
-    - `state_ctr`: an integer indicating how many stateful signatures the SHRINCS keypair has
-      previously issued.
+    - `state_ctr`: a signed integer, the number of stateful signatures the keypair has
+      previously issued (a negative value is explicitly invalid).
   - Outputs:
-    - The left-to-right index of the next WOTS+C leaf in the FXMSS tree that should be used.
-    - The bottom-to-top height of the next WOTS+C leaf in the FXMSS tree that should be used.
+    - a 64-bit unsigned integer, the left-to-right index of the next WOTS+C leaf in the FXMSS tree.
+    - an 8-bit unsigned integer, the bottom-to-top height of the next WOTS+C leaf in the FXMSS tree.
 
   Returns `None` if `state_ctr` is set to any negative number, or if `state_ctr + 1` exceeds the
   number of WOTS+C leaves in the FXMSS tree (as defined by its structure).
 
   This function is only used in the stateful path, and only by the signer.
   """
+  assert len(structure) == 2
   tree_shape, tree_depth = structure[0], structure[1]
   if tree_shape == FXMSS_SHAPE_UNBALANCED:
     if state_ctr == tree_depth and tree_depth > 0:
@@ -1277,24 +1395,21 @@ def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[Tuple[i
 
 def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand: Optional[bytes]) -> bytes:
   """
-  The SHRINCS signing function. Signs `message` with the serialized SHRINCS secret key
-  `shrincs_seckey`. If `state_ctr` is non-negative and valid for the stateful tree
-  structure specified in the secret key, then this function will use the stateful path and
-  will return a variable-length FXMSS signature. Otherwise it will fall back to the
-  stateless signing path and use SLH-DSA to sign the message.
+  The SHRINCS signing function. Signs `message` with the serialized secret key `shrincs_seckey`:
+  uses the stateful FXMSS path when `state_ctr` is valid for the key's tree structure, otherwise
+  falls back to the stateless SLH-DSA path.
 
   - Inputs:
-    - `message`: an arbitrary-length byte string.
+    - `message`: a message of at most `2**61 - 1 - 98` bytes.
     - `shrincs_seckey`: an 82-byte SHRINCS secret key.
-    - `state_ctr`: an integer indicating how many stateful signatures the SHRINCS keypair has
-      previously issued.
-    - `opt_rand`: (optional) a 16-byte string used to salt the randomizer in SLH-DSA. Not used
-      in the stateful signing path. If omitted, the stateless signing path will use the
-      deterministic variant of SLH-DSA.
+    - `state_ctr`: a signed integer, the number of stateful signatures the keypair has
+      previously issued (a negative value is explicitly invalid).
+    - `opt_rand`: an optional 16-byte salt for the randomizer in SLH-DSA (unused in the stateful path;
+      if omitted, the stateless path uses the deterministic variant of SLH-DSA).
   - Output:
-    - A variable-length SHRINCS signature (a byte string).
+    - a variable-length SHRINCS signature.
 
-  This function is only used by the signer.
+  This function is used only by the signer.
 
   > [!CAUTION]
   > Using the same key to sign different `message` values with the same `state_ctr` is
@@ -1305,6 +1420,10 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   > The only exception is for invalid (i.e. negative) values of `state_ctr`, which
   > explicitly trigger use of the stateful path.
   """
+  assert len(shrincs_seckey) == 82
+  assert opt_rand is None or len(opt_rand) == 16
+  assert len(message) <= 2**61 - 1 - 98
+
   sk_seed      = shrincs_seckey[0:16]
   sk_prf       = shrincs_seckey[16:32]
   pk_seed      = shrincs_seckey[32:48]
@@ -1316,7 +1435,7 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
 
   # Stateless signing path.
   if leaf_position is None:
-    # bind the stateless signature to the stateful keypair.
+    # Bind the stateless signature to the stateful keypair.
     return slh_dsa_sign(sf_root + message, b"", sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
 
   # Stateful signing path.
@@ -1326,7 +1445,7 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   ADRS[1:9] = leaf_index.to_bytes(8)
   R = PRF_msg_sf(sk_prf, pk_seed, ADRS, message)
 
-  # bind the stateful signature to the stateless keypair.
+  # Bind the stateful signature to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, sl_root + message)
   fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, sf_structure)
 
@@ -1335,32 +1454,35 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
 
 def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> bool:
   """
-  The SHRINCS verification procedure. Returns true if `signature` is a valid stateful
-  or stateless SHRINCS signature on `message`, issued by the given `shrincs_pubkey`.
+  The SHRINCS verification function. Returns true iff `signature` is a valid stateful or stateless
+  SHRINCS signature on `message` under `shrincs_pubkey`.
 
   Based on the length of `signature`, the verifier either recomputes `sf_root`
   (stateful path) or recomputes `sl_root` (stateless path), and compares the result
   against the public key.
 
   - Inputs:
-    - `message`: an arbitrary-length byte string.
-    - `signature`: an arbitrary-length byte string, claimed to be a SHRINCS signature.
-    - `shrincs_pubkey`: an 48-byte SHRINCS public key.
+    - `message`: a message of at most `2**61 - 1 - 98` bytes.
+    - `signature`: a purported SHRINCS signature of arbitrary length.
+    - `shrincs_pubkey`: a 48-byte SHRINCS public key.
   - Output:
-    - A boolean indicating if the signature is valid.
+    - a boolean indicating if the signature is valid.
 
   This function is used only by the verifier.
   """
+  assert len(shrincs_pubkey) == 48
+  assert len(message) <= 2**61 - 1 - 98
+
   pk_seed = shrincs_pubkey[0:16]
   sl_root = shrincs_pubkey[16:32]
   sf_root = shrincs_pubkey[32:48]
 
-  # Stateless verification path
+  # Stateless verification path.
   if len(signature) == 16 * (1 + SPHX_FORS_COUNT * (SPHX_FORS_HEIGHT + 1) + SPHX_LAYER_COUNT * (WOTS_TW_CHAIN_COUNT + SPHX_XMSS_HEIGHT)):
-    # stateless signatures must be bound to the stateful keypair.
+    # Stateless signatures must be bound to the stateful keypair.
     return slh_dsa_verify(sf_root + message, signature, b"", pk_seed, sl_root)
 
-  # Stateful verification path
+  # Stateful verification path.
   if len(signature) < 24:
     return False
 
@@ -1379,13 +1501,18 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
     return False
 
   leaf_depth = (len(fxmss_signature) - 2) // 16 - WOTS_C_CHAIN_COUNT
+
+  # Reject a leaf_index that names no position in a tree of this depth
+  if leaf_index >= 2 ** min(64, leaf_depth):
+    return False
+
   leaf_height = FXMSS_HEIGHT - leaf_depth
 
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
 
-  # stateful signatures must be bound to the stateless keypair.
+  # Stateful signatures must be bound to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, sl_root + message)
   root = fxmss_pubkey_from_sig(leaf_index, fxmss_signature, message_digest, pk_seed)
   return root is not None and root == sf_root

--- a/leaf-version-0xC2.mediawiki
+++ b/leaf-version-0xC2.mediawiki
@@ -143,12 +143,12 @@ We now define the signature verification algorithms for these two flags.
 
 A SHRINCS public key is a 48-byte string constructed as:
 <pre>
-PK = PK.seed || PK.sf_root || PK.sl_root
+PK = PK.seed || PK.sl_root || PK.sf_root
 </pre>
 
 * <code>PK.seed</code> is a domain separator, used in all hash operations while producing the signature.
-* <code>PK.sf_root</code> is a root commitment to a stateful XMSS public key.
 * <code>PK.sl_root</code> is a root commitment to a stateless SPHINCS public key.
+* <code>PK.sf_root</code> is a root commitment to a stateful XMSS public key.
 
 
 ====Signature Format====

--- a/pydoc_insert.py
+++ b/pydoc_insert.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import re
+import inspect
 from argparse import ArgumentParser
 import shutil
 
@@ -26,7 +27,7 @@ class SpecFunction:
     code_start_line = positions[1][0] - 1
     code_end_line = positions[-1][0]
     if fn.__doc__ is not None:
-      self.docstring = '\n'.join(fn.__doc__.strip().split('\n  '))
+      self.docstring = inspect.cleandoc(fn.__doc__)
     else:
       self.docstring = None
     self.codestring = '\n'.join([shrincs_code_lines[def_line], *shrincs_code_lines[code_start_line : code_end_line]])


### PR DESCRIPTION
Cleanup of the reference code and spec, plus a verifier fix. Bigger spec work is at the end.

### Correctness
- `shrincs_verify` no longer crashes on bad input. A crafted signature could carry a `leaf_index` too large for the tree depth its length implies. That hit an `assert` in `fxmss_pubkey_from_sig` and raised, so a bad signature could crash the verifier: a denial-of-service. Now `shrincs_verify` checks `leaf_index` first and returns `False`. The `assert` stays as a caller precondition.

Checked against current main. A 554-byte crafted signature (`R`, `leaf_index = 5`, a depth-1 FXMSS part):

```
main cd4d0a6:  shrincs_verify(..., crafted) -> AssertionError   (crash)
this branch:   shrincs_verify(..., crafted) -> False            (rejected)
```

A valid signature verifies on both.

### Preconditions
- Added `assert`s stating each function's input domain: fixed byte lengths and the integer ranges that fit the `ADRS` fields. A bad input now fails at the assert.

### Documentation and spec
- Made every docstring follow one shape: `The <name> function. <what it does>.`, present tense, no repeating the argument list, one line for which path and role uses it, each argument named by role and size ("a 16-byte salt"). Dropped the mixed "byte string" and "array" wording.
- Fixed two wrong "used by" notes: `xmss_pubkey_from_sig` (signer and verifier, not signer only), `wots_c_pubkey_from_sig` (verifier only, not both).
- Stated that all integers are fixed-width big-endian. The code left this to Python's default, which another implementation cannot see.
- Fixed a docs mismatch: the public-key byte order in `leaf-version-0xC2.mediawiki` now matches the code and `SHRINCS.md` (`seed || sl_root || sf_root`).
- Minor renames, punctuation, and capitalization fixes.

### Tooling
- Fixed `pydoc_insert.py`: its old dedent flattened the nested Input/Output bullets. It now uses `inspect.cleandoc`, which keeps the nesting.

### Design changes I would like to propose:
1. Make the sign function return an `Optional`, returning `None` on failure instead of raising. WOTS+C grinding can very rarely run out of counters, which today raises. `None` lets the caller handle it, and the type checker can see it.
2. Bound the signature length in `shrincs_verify`. Add named constants for the stateless length and the stateful lower and upper bounds, check the length against them before routing or slicing.
3. Rename SLH-DSA to SPHINCS. SLH-DSA is the only name from a published standard. Everything else is named after its primitive (WOTS-TW, WOTS+C, XMSS, FXMSS, FORS, hypertree). The parameter set is not a FIPS one, so the name suggests a conformance that does not hold. The docs already mix both names. Kept SLH-DSA here to match the earlier rename.