### PR TITLE
return None when WOTS+C grinding counter is exhausted

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -1021,6 +1021,15 @@ def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: by
 
 We max out at 2<sup>16</sup> grinding attempts because the counter is serialized as a 16-bit unsigned integer in the WOTS+C signature encoding - Counters larger than this would not fit into a signature. There is technically a chance that the signer may exhaust all of these attempts without finding a valid counter, however we have engineered our parameter set such that this probability is less than 1 chance in 2<sup>1000</sup>[^wotsgrind] - practically impossible.
 
+> [!INFO]
+>
+> While the declared return type of `wots_c_grind_to_constant_sum` suggests it may return `None`, this
+> is such a low probability event due to the parameters we use, that it is essentially impossible
+> in our universe. The `Optional` return type is needed only to satisfy formal verification of the
+> SHRINCS specification, which must account for even extremely low-probability paths in the
+> control flow of the signing algorithm. Real-world implementations may treat `wots_c_grind_to_constant_sum` as
+> infallible, provided all input invariants are satisfied.
+
 
 #### `wots_c_map_digest(...)`
 
@@ -1122,6 +1131,15 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
   return counter.to_bytes(2) + concat(signature)
 ```
 <!-- DOC END wots_c_sign -->
+
+> [!INFO]
+>
+> While the declared return type of `wots_c_sign` suggests it may return `None`, this
+> is such a low probability event due to the parameters we use, that it is essentially impossible
+> in our universe. The `Optional` return type is needed only to satisfy formal verification of the
+> SHRINCS specification, which must account for even extremely low-probability paths in the
+> control flow of the signing algorithm. Real-world implementations may treat `wots_c_sign` as
+> infallible, provided all input invariants are satisfied.
 
 
 #### `wots_c_pubkey_from_sig(...)`
@@ -1626,6 +1644,15 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
   return sig
 ```
 <!-- DOC END fxmss_sign -->
+
+> [!INFO]
+>
+> While the declared return type of `fxmss_sign` suggests it may return `None`, this
+> is such a low probability event due to the parameters we use, that it is essentially impossible
+> in our universe. The `Optional` return type is needed only to satisfy formal verification of the
+> SHRINCS specification, which must account for even extremely low-probability paths in the
+> control flow of the signing algorithm. Real-world implementations may treat `fxmss_sign` as
+> infallible, provided all input invariants are satisfied.
 
 
 #### `fxmss_pubkey_from_sig(...)`
@@ -2267,6 +2294,14 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
 ```
 <!-- DOC END shrincs_sign -->
 
+> [!INFO]
+>
+> While the declared return type of `shrincs_sign` suggests it may return `None`, this
+> is such a low probability event due to the parameters we use, that it is essentially impossible
+> in our universe. The `Optional` return type is needed only to satisfy formal verification of the
+> SHRINCS specification, which must account for even extremely low-probability paths in the
+> control flow of the signing algorithm. Real-world implementations may treat `shrincs_sign` as
+> infallible, provided all input invariants are satisfied.
 
 #### `shrincs_verify(...)`
 

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -1007,7 +1007,7 @@ constant-sum index set, returning the lowest such counter and its index set.
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: bytearray) -> tuple[int, list[int]]:
+def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: bytearray) -> Optional[tuple[int, list[int]]]:
   ADRS[9] = SF_WOTS_C_GRIND
   for i in range(2**16):
     hashed = H_grind(pk_seed, ADRS, message_digest, i)
@@ -1015,7 +1015,7 @@ def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: by
     if sum(indexes) == WOTS_C_CONSTANT_SUM:
       return (i, indexes)
 
-  raise RuntimeError("Unreachable") # practically impossible
+  return None # practically impossible
 ```
 <!-- DOC END wots_c_grind_to_constant_sum -->
 
@@ -1103,8 +1103,12 @@ keypair location prefilled in `ADRS`.
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
-  counter, indexes = wots_c_grind_to_constant_sum(pk_seed, message_digest, ADRS)
+def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> Optional[bytes]:
+  grinded = wots_c_grind_to_constant_sum(pk_seed, message_digest, ADRS)
+  if grinded is None:
+    return None # practically impossible
+
+  counter, indexes = grinded
   signature = [b''] * WOTS_C_CHAIN_COUNT
 
   ADRS[10:14] = zeros(4) # zeros reserved
@@ -1596,7 +1600,7 @@ The FXMSS signing function. Produces a deterministic WOTS+C signature at the lea
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_height: int, pk_seed: bytes, structure: bytes) -> bytes:
+def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_height: int, pk_seed: bytes, structure: bytes) -> Optional[bytes]:
   leaf_depth = FXMSS_HEIGHT - leaf_height
 
   # Validate the leaf is positioned correctly for the specified tree structure.
@@ -1610,6 +1614,8 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
   sig = wots_c_sign(message_digest, sk_seed, pk_seed, ADRS)
+  if sig is None:
+    return None # practically impossible
 
   # Append the Merkle authentication path.
   for j in range(leaf_depth):
@@ -2227,7 +2233,7 @@ This function is used only by the signer.
 > the stateless path.
 
 ```py
-def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand: Optional[bytes]) -> bytes:
+def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand: Optional[bytes]) -> Optional[bytes]:
   sk_seed      = shrincs_seckey[0:16]
   sk_prf       = shrincs_seckey[16:32]
   pk_seed      = shrincs_seckey[32:48]
@@ -2253,6 +2259,8 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   # Bind the stateful signature to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, bound_message)
   fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, sf_structure)
+  if fxmss_signature is None:
+    return None # practically impossible
 
   # TODO: compact encoding for leaf index
   return R + leaf_index.to_bytes(8) + fxmss_signature

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -1022,13 +1022,7 @@ def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: by
 We max out at 2<sup>16</sup> grinding attempts because the counter is serialized as a 16-bit unsigned integer in the WOTS+C signature encoding - Counters larger than this would not fit into a signature. There is technically a chance that the signer may exhaust all of these attempts without finding a valid counter, however we have engineered our parameter set such that this probability is less than 1 chance in 2<sup>1000</sup>[^wotsgrind] - practically impossible.
 
 > [!INFO]
->
-> While the declared return type of `wots_c_grind_to_constant_sum` suggests it may return `None`, this
-> is such a low probability event due to the parameters we use, that it is essentially impossible
-> in our universe. The `Optional` return type is needed only to satisfy formal verification of the
-> SHRINCS specification, which must account for even extremely low-probability paths in the
-> control flow of the signing algorithm. Real-world implementations may treat `wots_c_grind_to_constant_sum` as
-> infallible, provided all input invariants are satisfied.
+> [The `return None` control path can typically be ignored in real-world implementations](#on-signing-fallibility).
 
 
 #### `wots_c_map_digest(...)`
@@ -1133,13 +1127,7 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
 <!-- DOC END wots_c_sign -->
 
 > [!INFO]
->
-> While the declared return type of `wots_c_sign` suggests it may return `None`, this
-> is such a low probability event due to the parameters we use, that it is essentially impossible
-> in our universe. The `Optional` return type is needed only to satisfy formal verification of the
-> SHRINCS specification, which must account for even extremely low-probability paths in the
-> control flow of the signing algorithm. Real-world implementations may treat `wots_c_sign` as
-> infallible, provided all input invariants are satisfied.
+> [The `return None` control path can typically be ignored in real-world implementations](#on-signing-fallibility).
 
 
 #### `wots_c_pubkey_from_sig(...)`
@@ -1646,13 +1634,7 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
 <!-- DOC END fxmss_sign -->
 
 > [!INFO]
->
-> While the declared return type of `fxmss_sign` suggests it may return `None`, this
-> is such a low probability event due to the parameters we use, that it is essentially impossible
-> in our universe. The `Optional` return type is needed only to satisfy formal verification of the
-> SHRINCS specification, which must account for even extremely low-probability paths in the
-> control flow of the signing algorithm. Real-world implementations may treat `fxmss_sign` as
-> infallible, provided all input invariants are satisfied.
+> [The `return None` control path can typically be ignored in real-world implementations](#on-signing-fallibility).
 
 
 #### `fxmss_pubkey_from_sig(...)`
@@ -2295,13 +2277,7 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
 <!-- DOC END shrincs_sign -->
 
 > [!INFO]
->
-> While the declared return type of `shrincs_sign` suggests it may return `None`, this
-> is such a low probability event due to the parameters we use, that it is essentially impossible
-> in our universe. The `Optional` return type is needed only to satisfy formal verification of the
-> SHRINCS specification, which must account for even extremely low-probability paths in the
-> control flow of the signing algorithm. Real-world implementations may treat `shrincs_sign` as
-> infallible, provided all input invariants are satisfied.
+> [The `return None` control path can typically be ignored in real-world implementations](#on-signing-fallibility).
 
 #### `shrincs_verify(...)`
 
@@ -2366,6 +2342,15 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
   return root is not None and root == sf_root
 ```
 <!-- DOC END shrincs_verify -->
+
+
+## On Signing Fallibility
+
+The declared return type of some signer functions like `fxmss_sign` is `Optional`, indicating the function may return `None` f the function fails. This originates from an edgecase condition in `wots_c_grind_to_constant_sum` and bubbles up the stack in the stateful signing path, all the way up to `shrincs_sign`.
+
+While this edgecase is technically possible to hit, it has such a low probability due to the parameters we use that it is essentially impossible in our universe. See [the docs for `wots_c_grind_to_constant_sum`](#wots_c_grind_to_constant_sum) to see why.
+
+Still, as this python code is the official specification of SHRINCS, we must account for even extremely low-probability paths in the control flow of the algorithms. Real-world implementations may treat `shrincs_sign`, `fxmss_sign`, `wots_c_sign`, and `wots_c_grind_to_constant_sum` as infallible functions, provided all input invariants are satisfied.
 
 
 ## Reference Implementation

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -462,7 +462,7 @@ def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, AD
   wots_pk_hash = T_sl(pk_seed, ADRS, concat(wots_pk))
   return wots_pk_hash
 
-def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: bytearray) -> tuple[int, list[int]]:
+def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: bytearray) -> Optional[tuple[int, list[int]]]:
   """
   The WOTS+C grinding function. Grinds up to 2^16 counters until one maps `message_digest` to a
   constant-sum index set, returning the lowest such counter and its index set.
@@ -484,7 +484,7 @@ def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: by
     if sum(indexes) == WOTS_C_CONSTANT_SUM:
       return (i, indexes)
 
-  raise RuntimeError("Unreachable") # practically impossible
+  return None # practically impossible
 
 def wots_c_map_digest(pk_seed: bytes, message_digest: bytes, ADRS: bytearray, counter: int) -> Optional[list[int]]:
   """
@@ -538,7 +538,7 @@ def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   wots_pk_hash = T_sf(pk_seed, ADRS, concat(wots_pk))
   return wots_pk_hash
 
-def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> Optional[bytes]:
   """
   The WOTS+C signing function. Produces a WOTS+C signature on a 32-byte `message_digest`, at the
   keypair location prefilled in `ADRS`.
@@ -553,7 +553,11 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
 
   This function is only used in the stateful path, and only by the signer.
   """
-  counter, indexes = wots_c_grind_to_constant_sum(pk_seed, message_digest, ADRS)
+  grinded = wots_c_grind_to_constant_sum(pk_seed, message_digest, ADRS)
+  if grinded is None:
+    return None # practically impossible
+
+  counter, indexes = grinded
   signature = [b''] * WOTS_C_CHAIN_COUNT
 
   ADRS[10:14] = zeros(4) # zeros reserved
@@ -815,7 +819,7 @@ def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes
   ADRS[10:22] = zeros(12)
   return H(pk_seed, ADRS, lchild + rchild)
 
-def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_height: int, pk_seed: bytes, structure: bytes) -> bytes:
+def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_height: int, pk_seed: bytes, structure: bytes) -> Optional[bytes]:
   """
   The FXMSS signing function. Produces a deterministic WOTS+C signature at the leaf given by
   `leaf_index`/`leaf_height` and appends the Merkle authentication path to form an FXMSS signature.
@@ -845,6 +849,8 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
   sig = wots_c_sign(message_digest, sk_seed, pk_seed, ADRS)
+  if sig is None:
+    return None # practically impossible
 
   # Append the Merkle authentication path.
   for j in range(leaf_depth):
@@ -1267,7 +1273,7 @@ def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[tuple[i
   # - state is negative
   return None
 
-def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand: Optional[bytes]) -> bytes:
+def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand: Optional[bytes]) -> Optional[bytes]:
   """
   The SHRINCS signing function. Signs `message` with the serialized secret key `shrincs_seckey`:
   uses the stateful FXMSS path when `state_ctr` is valid for the key's tree structure, otherwise
@@ -1319,6 +1325,8 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   # Bind the stateful signature to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, bound_message)
   fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, sf_structure)
+  if fxmss_signature is None:
+    return None # practically impossible
 
   # TODO: compact encoding for leaf index
   return R + leaf_index.to_bytes(8) + fxmss_signature


### PR DESCRIPTION
Fixes #15

As described in the docs of `wots_c_grind_to_constant_sum`, the chance of grinding failing is less than 1 in 2<sup>1000</sup>, but as @remix7531 points out in #15, even a tiny probability of failure messes up formal verification of SHRINCS by breaking totality, so we must account for it in the spec. Alternatives like rejection sampling or silent failure would only move the problem elsewhere.

This PR fixes #15 by modifying `wots_c_grind_to_constant_sum` and all downstream stateful signing algorithms to return an `Optional` (nullable) type. This ensures the spec accurately reflects the remote possibility of failure.