### PR TITLE
H_msg_sf inner collision fix 1: add pk_roots as explicit parameters

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -721,6 +721,7 @@ The `H_msg_sl` message hash function. Produces the 32-byte signing digest for th
   - `R`: a 16-byte randomizer.
   - `pk_seed`: a 16-byte salt.
   - `sl_root`: the 16-byte stateless root hash.
+  - `sf_root`: the 16-byte stateful root hash.
   - `M`: a variable-length message.
 - Output:
   - a 32-byte hash.
@@ -730,8 +731,8 @@ This function is only used in the stateless path, and by both the signer and the
 Note that `pk_seed` is not padded in this keyed hash function.
 
 ```py
-def H_msg_sl(R: bytes, pk_seed: bytes, sl_root: bytes, M: bytes) -> bytes:
-  return sha256(R + pk_seed + sha256(R + pk_seed + sl_root + M) + zeros(4))
+def H_msg_sl(R: bytes, pk_seed: bytes, sl_root: bytes, sf_root: bytes, M: bytes) -> bytes:
+  return sha256(R + pk_seed + sha256(R + pk_seed + sl_root + sf_root + M) + zeros(4))
 ```
 <!-- DOC END H_msg_sl -->
 
@@ -746,6 +747,7 @@ The `H_msg_sf` message hash function. Produces the 32-byte signing digest for th
 - Inputs:
   - `R`: a 16-byte randomizer.
   - `pk_seed`: a 16-byte salt.
+  - `sl_root`: the 16-byte stateless root hash.
   - `sf_root`: the 16-byte stateful root hash.
   - `ADRS`: a 22-byte address.
   - `M`: a variable-length message.
@@ -757,8 +759,8 @@ This function is only used in the stateful path, and by both the signer and the 
 Note that `pk_seed` is not padded in this tweakable hash function.
 
 ```py
-def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes) -> bytes:
-  return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + sf_root + ADRS[:9] + M))
+def H_msg_sf(R: bytes, pk_seed: bytes, sl_root: bytes, sf_root: bytes, ADRS: bytearray, M: bytes) -> bytes:
+  return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + sf_root + ADRS[:9] + sl_root + M))
 ```
 <!-- DOC END H_msg_sf -->
 
@@ -1991,7 +1993,7 @@ This function is only used in the stateless path, and by both the signer and the
 
 ```py
 def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: bytes) -> tuple[bytes, int, int]:
-  digest = H_msg_sl(R, pk_seed, sl_root, message)
+  digest = H_msg_sl(R, pk_seed, sl_root, message[:16], message[16:])
 
   fors_digest = digest[:FORS_DIGEST_SIZE]
   offset = FORS_DIGEST_SIZE
@@ -2344,7 +2346,7 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   R = PRF_msg_sf(sk_prf, pk_seed, ADRS, bound_message)
 
   # Bind the stateful signature to the stateless keypair.
-  message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, bound_message)
+  message_digest = H_msg_sf(R, pk_seed, sl_root, sf_root, ADRS, message)
   fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, sf_structure)
   if fxmss_signature is None:
     return None # practically impossible
@@ -2411,7 +2413,7 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
     ADRS[1:9] = leaf_index.to_bytes(8)
 
     # Stateful signatures must be bound to the stateless keypair.
-    message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, sl_root + message)
+    message_digest = H_msg_sf(R, pk_seed, sl_root, sf_root, ADRS, message)
     root = fxmss_pubkey_from_sig(leaf_index, fxmss_signature, message_digest, pk_seed)
     if root is None:
       return False

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -673,8 +673,8 @@ or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA, wh
 resistance to side-channel attacks).
 
 ```py
-def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
-  return hmac_sha256(key=sk_prf, message=opt_rand + M)[:16]
+def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, sf_root: bytes, M: bytes) -> bytes:
+  return hmac_sha256(key=sk_prf, message=opt_rand + sf_root + M)[:16]
 ```
 <!-- DOC END PRF_msg_sl -->
 
@@ -696,8 +696,8 @@ HMAC-SHA256.
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> bytes:
-  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), message=pk_seed + ADRS[:9] + M)[:16]
+def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, sl_root: bytes, M: bytes) -> bytes:
+  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), message=pk_seed + ADRS[:9] + sl_root + M)[:16]
 ```
 <!-- DOC END PRF_msg_sf -->
 
@@ -2040,7 +2040,7 @@ def slh_dsa_sign_internal(message: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed
   if opt_rand is None:
     opt_rand = pk_seed # deterministic mode
 
-  R = PRF_msg_sl(sk_prf, opt_rand, message)
+  R = PRF_msg_sl(sk_prf, opt_rand, message[:16], message[16:])
   fors_digest, tree_index, leaf_index = slh_dsa_digest_message(R, pk_seed, sl_root, message)
 
   ADRS = bytearray(22)
@@ -2338,12 +2338,11 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
     return slh_dsa_sign(sf_root + message, b"", sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
 
   # Stateful signing path.
-  bound_message = sl_root + message # Bind the stateful signature to the stateless keypair
   leaf_index, leaf_height = leaf_position
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
-  R = PRF_msg_sf(sk_prf, pk_seed, ADRS, bound_message)
+  R = PRF_msg_sf(sk_prf, pk_seed, ADRS, sl_root, message)
 
   # Bind the stateful signature to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sl_root, sf_root, ADRS, message)

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -258,7 +258,7 @@ def PRF(pk_seed: bytes, sk_seed: bytes, ADRS: bytearray) -> bytes:
   """
   return sha256(pk_seed + zeros(48) + ADRS + sk_seed)[:16]
 
-def H_msg_sl(R: bytes, pk_seed: bytes, sl_root: bytes, M: bytes) -> bytes:
+def H_msg_sl(R: bytes, pk_seed: bytes, sl_root: bytes, sf_root: bytes, M: bytes) -> bytes:
   """
   The `H_msg_sl` message hash function. Produces the 32-byte signing digest for the stateless path.
 
@@ -266,6 +266,7 @@ def H_msg_sl(R: bytes, pk_seed: bytes, sl_root: bytes, M: bytes) -> bytes:
     - `R`: a 16-byte randomizer.
     - `pk_seed`: a 16-byte salt.
     - `sl_root`: the 16-byte stateless root hash.
+    - `sf_root`: the 16-byte stateful root hash.
     - `M`: a variable-length message.
   - Output:
     - a 32-byte hash.
@@ -274,15 +275,16 @@ def H_msg_sl(R: bytes, pk_seed: bytes, sl_root: bytes, M: bytes) -> bytes:
 
   Note that `pk_seed` is not padded in this keyed hash function.
   """
-  return sha256(R + pk_seed + sha256(R + pk_seed + sl_root + M) + zeros(4))
+  return sha256(R + pk_seed + sha256(R + pk_seed + sl_root + sf_root + M) + zeros(4))
 
-def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes) -> bytes:
+def H_msg_sf(R: bytes, pk_seed: bytes, sl_root: bytes, sf_root: bytes, ADRS: bytearray, M: bytes) -> bytes:
   """
   The `H_msg_sf` message hash function. Produces the 32-byte signing digest for the stateful path.
 
   - Inputs:
     - `R`: a 16-byte randomizer.
     - `pk_seed`: a 16-byte salt.
+    - `sl_root`: the 16-byte stateless root hash.
     - `sf_root`: the 16-byte stateful root hash.
     - `ADRS`: a 22-byte address.
     - `M`: a variable-length message.
@@ -293,7 +295,7 @@ def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes
 
   Note that `pk_seed` is not padded in this tweakable hash function.
   """
-  return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + sf_root + ADRS[:9] + M))
+  return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + sf_root + ADRS[:9] + sl_root + M))
 
 def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   """
@@ -1077,7 +1079,8 @@ def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: by
 
   This function is only used in the stateless path, and by both the signer and the verifier.
   """
-  digest = H_msg_sl(R, pk_seed, sl_root, message)
+  # First 16 bytes are always the `sf_root`.
+  digest = H_msg_sl(R, pk_seed, sl_root, message[:16], message[16:])
 
   fors_digest = digest[:FORS_DIGEST_SIZE]
   offset = FORS_DIGEST_SIZE
@@ -1341,7 +1344,7 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   R = PRF_msg_sf(sk_prf, pk_seed, ADRS, bound_message)
 
   # Bind the stateful signature to the stateless keypair.
-  message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, bound_message)
+  message_digest = H_msg_sf(R, pk_seed, sl_root, sf_root, ADRS, message)
   fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, sf_structure)
   if fxmss_signature is None:
     return None # practically impossible
@@ -1400,7 +1403,7 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
     ADRS[1:9] = leaf_index.to_bytes(8)
 
     # Stateful signatures must be bound to the stateless keypair.
-    message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, sl_root + message)
+    message_digest = H_msg_sf(R, pk_seed, sl_root, sf_root, ADRS, message)
     root = fxmss_pubkey_from_sig(leaf_index, fxmss_signature, message_digest, pk_seed)
     if root is None:
       return False

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -297,7 +297,7 @@ def H_msg_sf(R: bytes, pk_seed: bytes, sl_root: bytes, sf_root: bytes, ADRS: byt
   """
   return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + sf_root + ADRS[:9] + sl_root + M))
 
-def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
+def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, sf_root: bytes, M: bytes) -> bytes:
   """
   The `PRF_msg_sl` pseudorandom function. Derives the per-message randomizer (salt) for the stateless path via
   HMAC-SHA256.
@@ -315,9 +315,9 @@ def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA, which increases
   resistance to side-channel attacks).
   """
-  return hmac_sha256(key=sk_prf, message=opt_rand + M)[:16]
+  return hmac_sha256(key=sk_prf, message=opt_rand + sf_root + M)[:16]
 
-def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> bytes:
+def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, sl_root: bytes, M: bytes) -> bytes:
   """
   The `PRF_msg_sf` function. Derives the per-message randomizer (salt) for the stateful path via
   HMAC-SHA256.
@@ -332,7 +332,7 @@ def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> byte
 
   This function is only used in the stateful path, and only by the signer.
   """
-  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), message=pk_seed + ADRS[:9] + M)[:16]
+  return hmac_sha256(key=sk_prf + repeat(0xFF, 48), message=pk_seed + ADRS[:9] + sl_root + M)[:16]
 
 
 #  Winternitz algorithms
@@ -1122,7 +1122,7 @@ def slh_dsa_sign_internal(message: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed
   if opt_rand is None:
     opt_rand = pk_seed # deterministic mode
 
-  R = PRF_msg_sl(sk_prf, opt_rand, message)
+  R = PRF_msg_sl(sk_prf, opt_rand, message[:16], message[16:])
   fors_digest, tree_index, leaf_index = slh_dsa_digest_message(R, pk_seed, sl_root, message)
 
   ADRS = bytearray(22)
@@ -1336,12 +1336,11 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
     return slh_dsa_sign(sf_root + message, b"", sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
 
   # Stateful signing path.
-  bound_message = sl_root + message # Bind the stateful signature to the stateless keypair
   leaf_index, leaf_height = leaf_position
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
-  R = PRF_msg_sf(sk_prf, pk_seed, ADRS, bound_message)
+  R = PRF_msg_sf(sk_prf, pk_seed, ADRS, sl_root, message)
 
   # Bind the stateful signature to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sl_root, sf_root, ADRS, message)


### PR DESCRIPTION
This is a first attempt to implement #30 to fix the inner collision that is possible currently on `H_msg_sf`.

However this change turned out to be a bit uglier in the code than I would've liked.

In order to preserve black-box compatibility with SLH-DSA, we can't take `sf_root` out of the message (that's passed opaquely to `PRF_msg_sl` and to other SLH-DSA business logic), so I had to slice off the `sf_root` from the first 16 bytes of the message.

In `shrincs_sign`, i had to awkwardly drop the usage of the `bound_message` variable which is now used only in the `PRF_msg_sf` invocation, and it's not clear why we do things that way in the code, so we might need further refactoring to make `sl_root` an explicit parameter of `PRF_msg_sf`... which makes it asymmetric compared to `PRF_msg_sl`... etc etc. Lots of problems.

This PR is just a draft, because I have an alternative fix for the collision problem which I'd like to assess before continuing down this road.