### PR TITLE
H_msg_sf inner collision fix 2: remove ADRS[:9] from outer H_msg_sf

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -758,7 +758,7 @@ Note that `pk_seed` is not padded in this tweakable hash function.
 
 ```py
 def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes) -> bytes:
-  return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + sf_root + ADRS[:9] + M))
+  return sha256(R + pk_seed + sha256(R + pk_seed + sf_root + ADRS[:9] + M))
 ```
 <!-- DOC END H_msg_sf -->
 

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -293,7 +293,7 @@ def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes
 
   Note that `pk_seed` is not padded in this tweakable hash function.
   """
-  return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + sf_root + ADRS[:9] + M))
+  return sha256(R + pk_seed + sha256(R + pk_seed + sf_root + ADRS[:9] + M))
 
 def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   """


### PR DESCRIPTION
This is an alternative attempt to fix #30 (also see #34). While #34 is a pure refactor which changes the arguments of `H_msg_sf` to make our root hash prepending practice explicit in the `H_msg_sf` function signature, this change modifies the tweakable hash function itself.

This change removes `ADRS[:9]` from the outer hash of `H_msg_sf`. My motivation for this is straightforward: The collision attack claude found was owed to the attacker's control of `ADRS[:9]` in both the inner and outer preimages, allowing them to gain an advantage in grinding out a collision between the inner and outer hashes of `H_msg_sf`, by working to find an inner hash whose leading 7 bytes match the trailing 7 bytes of `sf_root`.

Removing `ADRS[:9]` from the outer hash invocation removes all attacker-controlled parameters from the outer hash, which aligns with SLH-DSA's `H_msg_sl` behavior. No more collisions.

@error0024 do you see any other problems by removing `ADRS[:9]`?