### PR TITLE
Make the state counter an unsigned 64-bit integer

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -2253,19 +2253,22 @@ next WOTS+C leaf for the given `structure` and `state_ctr`.
 - Inputs:
   - `structure`: a 2-byte identifier describing the FXMSS tree structure.
   - `state_ctr`: a 64-bit unsigned integer, the number of stateful signatures the keypair has
-    previously issued.
+    previously issued, or `None`.
 - Outputs:
   - a 64-bit unsigned integer, the left-to-right index of the next WOTS+C leaf in the FXMSS tree.
   - an 8-bit unsigned integer, the bottom-to-top height of the next WOTS+C leaf in the FXMSS tree.
 
-Returns `None` if `state_ctr` is at least the number of WOTS+C leaves in the FXMSS tree (as
-defined by its structure). A depth-zero tree has no usable leaf, so a depth-zero key signs only
-on the stateless path.
+Returns `None` if `state_ctr` is `None`, or if it is at least the number of WOTS+C leaves in the
+FXMSS tree (as defined by its structure). A depth-zero tree has no usable leaf, so a depth-zero
+key signs only on the stateless path.
 
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[tuple[int, int]]:
+def shrincs_sf_leaf_select(structure: bytes, state_ctr: Optional[int]) -> Optional[tuple[int, int]]:
+  if state_ctr is None:
+    return None
+
   tree_shape, tree_depth = structure[0], structure[1]
 
   # A depth-zero tree holds no usable WOTS+C leaf.
@@ -2324,10 +2327,7 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int]
   sf_structure = shrincs_seckey[64:66]
   sf_root      = shrincs_seckey[66:82]
 
-  if state_ctr is None:
-    leaf_position = None
-  else:
-    leaf_position = shrincs_sf_leaf_select(sf_structure, state_ctr)
+  leaf_position = shrincs_sf_leaf_select(sf_structure, state_ctr)
 
   # Stateless signing path.
   if leaf_position is None:

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -2252,15 +2252,15 @@ next WOTS+C leaf for the given `structure` and `state_ctr`.
 
 - Inputs:
   - `structure`: a 2-byte identifier describing the FXMSS tree structure.
-  - `state_ctr`: a signed integer, the number of stateful signatures the keypair has
-    previously issued (a negative value is permitted, and makes the function return `None`).
+  - `state_ctr`: a 64-bit unsigned integer, the number of stateful signatures the keypair has
+    previously issued.
 - Outputs:
   - a 64-bit unsigned integer, the left-to-right index of the next WOTS+C leaf in the FXMSS tree.
   - an 8-bit unsigned integer, the bottom-to-top height of the next WOTS+C leaf in the FXMSS tree.
 
-Returns `None` if `state_ctr` is set to any negative number, or if `state_ctr + 1` exceeds the
-number of WOTS+C leaves in the FXMSS tree (as defined by its structure). A depth-zero tree has
-no usable leaf, so a depth-zero key signs only on the stateless path.
+Returns `None` if `state_ctr` is at least the number of WOTS+C leaves in the FXMSS tree (as
+defined by its structure). A depth-zero tree has no usable leaf, so a depth-zero key signs only
+on the stateless path.
 
 This function is only used in the stateful path, and only by the signer.
 
@@ -2275,16 +2275,15 @@ def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[tuple[i
   if tree_shape == FXMSS_SHAPE_UNBALANCED:
     if state_ctr == tree_depth:
       return (0, FXMSS_HEIGHT - tree_depth)
-    if 0 <= state_ctr < tree_depth:
+    if state_ctr < tree_depth:
       return (1, FXMSS_HEIGHT - 1 - state_ctr)
 
   elif tree_shape == FXMSS_SHAPE_BALANCED:
-    if 0 <= state_ctr < 2**tree_depth:
+    if state_ctr < 2**tree_depth:
       return (state_ctr, FXMSS_HEIGHT - tree_depth)
 
   # - unknown FXMSS tree shape
   # - no more signatures left
-  # - state is negative
   return None
 ```
 <!-- DOC END shrincs_sf_leaf_select -->
@@ -2300,8 +2299,8 @@ falls back to the stateless SLH-DSA path.
 - Inputs:
   - `message`: a message of at most `2**61 - 128` bytes.
   - `shrincs_seckey`: an 82-byte SHRINCS secret key.
-  - `state_ctr`: a signed integer, the number of stateful signatures the keypair has
-    previously issued (a negative value is permitted, and forces the stateless path).
+  - `state_ctr`: a 64-bit unsigned integer, the number of stateful signatures the keypair has
+    previously issued, or `None` to sign statelessly.
   - `opt_rand`: an optional 16-byte salt for the randomizer in SLH-DSA (unused in the stateful path;
     if omitted, the stateless path uses the deterministic variant of SLH-DSA).
 - Output:
@@ -2315,12 +2314,9 @@ This function is used only by the signer.
 > a security vulnerability. SHRINCS implementations must wrap `shrincs_sign` with code
 > which increments and saves the state counter as `state_ctr + 1` on a persistent,
 > non-recoverable storage medium before the signature is returned to the caller.
->
-> The only exception is for negative values of `state_ctr`, which explicitly force
-> the stateless path.
 
 ```py
-def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand: Optional[bytes]) -> Optional[bytes]:
+def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int], opt_rand: Optional[bytes]) -> Optional[bytes]:
   sk_seed      = shrincs_seckey[0:16]
   sk_prf       = shrincs_seckey[16:32]
   pk_seed      = shrincs_seckey[32:48]
@@ -2328,7 +2324,10 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   sf_structure = shrincs_seckey[64:66]
   sf_root      = shrincs_seckey[66:82]
 
-  leaf_position = shrincs_sf_leaf_select(sf_structure, state_ctr)
+  if state_ctr is None:
+    leaf_position = None
+  else:
+    leaf_position = shrincs_sf_leaf_select(sf_structure, state_ctr)
 
   # Stateless signing path.
   if leaf_position is None:

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -1250,7 +1250,7 @@ def shrincs_keygen(seed: bytes, sf_structure: bytes) -> tuple[bytes, bytes]:
   shrincs_pubkey = pk_seed + sl_root + sf_root
   return (shrincs_seckey, shrincs_pubkey)
 
-def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[tuple[int, int]]:
+def shrincs_sf_leaf_select(structure: bytes, state_ctr: Optional[int]) -> Optional[tuple[int, int]]:
   """
   The SHRINCS stateful-path leaf-selection function. Computes the position `(index, height)` of the
   next WOTS+C leaf for the given `structure` and `state_ctr`.
@@ -1258,17 +1258,20 @@ def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[tuple[i
   - Inputs:
     - `structure`: a 2-byte identifier describing the FXMSS tree structure.
     - `state_ctr`: a 64-bit unsigned integer, the number of stateful signatures the keypair has
-      previously issued.
+      previously issued, or `None`.
   - Outputs:
     - a 64-bit unsigned integer, the left-to-right index of the next WOTS+C leaf in the FXMSS tree.
     - an 8-bit unsigned integer, the bottom-to-top height of the next WOTS+C leaf in the FXMSS tree.
 
-  Returns `None` if `state_ctr` is at least the number of WOTS+C leaves in the FXMSS tree (as
-  defined by its structure). A depth-zero tree has no usable leaf, so a depth-zero key signs only
-  on the stateless path.
+  Returns `None` if `state_ctr` is `None`, or if it is at least the number of WOTS+C leaves in the
+  FXMSS tree (as defined by its structure). A depth-zero tree has no usable leaf, so a depth-zero
+  key signs only on the stateless path.
 
   This function is only used in the stateful path, and only by the signer.
   """
+  if state_ctr is None:
+    return None
+
   tree_shape, tree_depth = structure[0], structure[1]
 
   # A depth-zero tree holds no usable WOTS+C leaf.
@@ -1321,10 +1324,7 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int]
   sf_structure = shrincs_seckey[64:66]
   sf_root      = shrincs_seckey[66:82]
 
-  if state_ctr is None:
-    leaf_position = None
-  else:
-    leaf_position = shrincs_sf_leaf_select(sf_structure, state_ctr)
+  leaf_position = shrincs_sf_leaf_select(sf_structure, state_ctr)
 
   # Stateless signing path.
   if leaf_position is None:

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -1257,15 +1257,15 @@ def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[tuple[i
 
   - Inputs:
     - `structure`: a 2-byte identifier describing the FXMSS tree structure.
-    - `state_ctr`: a signed integer, the number of stateful signatures the keypair has
-      previously issued (a negative value is permitted, and makes the function return `None`).
+    - `state_ctr`: a 64-bit unsigned integer, the number of stateful signatures the keypair has
+      previously issued.
   - Outputs:
     - a 64-bit unsigned integer, the left-to-right index of the next WOTS+C leaf in the FXMSS tree.
     - an 8-bit unsigned integer, the bottom-to-top height of the next WOTS+C leaf in the FXMSS tree.
 
-  Returns `None` if `state_ctr` is set to any negative number, or if `state_ctr + 1` exceeds the
-  number of WOTS+C leaves in the FXMSS tree (as defined by its structure). A depth-zero tree has
-  no usable leaf, so a depth-zero key signs only on the stateless path.
+  Returns `None` if `state_ctr` is at least the number of WOTS+C leaves in the FXMSS tree (as
+  defined by its structure). A depth-zero tree has no usable leaf, so a depth-zero key signs only
+  on the stateless path.
 
   This function is only used in the stateful path, and only by the signer.
   """
@@ -1278,19 +1278,18 @@ def shrincs_sf_leaf_select(structure: bytes, state_ctr: int) -> Optional[tuple[i
   if tree_shape == FXMSS_SHAPE_UNBALANCED:
     if state_ctr == tree_depth:
       return (0, FXMSS_HEIGHT - tree_depth)
-    if 0 <= state_ctr < tree_depth:
+    if state_ctr < tree_depth:
       return (1, FXMSS_HEIGHT - 1 - state_ctr)
 
   elif tree_shape == FXMSS_SHAPE_BALANCED:
-    if 0 <= state_ctr < 2**tree_depth:
+    if state_ctr < 2**tree_depth:
       return (state_ctr, FXMSS_HEIGHT - tree_depth)
 
   # - unknown FXMSS tree shape
   # - no more signatures left
-  # - state is negative
   return None
 
-def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand: Optional[bytes]) -> Optional[bytes]:
+def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int], opt_rand: Optional[bytes]) -> Optional[bytes]:
   """
   The SHRINCS signing function. Signs `message` with the serialized secret key `shrincs_seckey`:
   uses the stateful FXMSS path when `state_ctr` is valid for the key's tree structure, otherwise
@@ -1299,8 +1298,8 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   - Inputs:
     - `message`: a message of at most `2**61 - 128` bytes.
     - `shrincs_seckey`: an 82-byte SHRINCS secret key.
-    - `state_ctr`: a signed integer, the number of stateful signatures the keypair has
-      previously issued (a negative value is permitted, and forces the stateless path).
+    - `state_ctr`: a 64-bit unsigned integer, the number of stateful signatures the keypair has
+      previously issued, or `None` to sign statelessly.
     - `opt_rand`: an optional 16-byte salt for the randomizer in SLH-DSA (unused in the stateful path;
       if omitted, the stateless path uses the deterministic variant of SLH-DSA).
   - Output:
@@ -1314,9 +1313,6 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   > a security vulnerability. SHRINCS implementations must wrap `shrincs_sign` with code
   > which increments and saves the state counter as `state_ctr + 1` on a persistent,
   > non-recoverable storage medium before the signature is returned to the caller.
-  >
-  > The only exception is for negative values of `state_ctr`, which explicitly force
-  > the stateless path.
   """
   sk_seed      = shrincs_seckey[0:16]
   sk_prf       = shrincs_seckey[16:32]
@@ -1325,7 +1321,10 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: int, opt_rand
   sf_structure = shrincs_seckey[64:66]
   sf_root      = shrincs_seckey[66:82]
 
-  leaf_position = shrincs_sf_leaf_select(sf_structure, state_ctr)
+  if state_ctr is None:
+    leaf_position = None
+  else:
+    leaf_position = shrincs_sf_leaf_select(sf_structure, state_ctr)
 
   # Stateless signing path.
   if leaf_position is None:

--- a/impl/test.py
+++ b/impl/test.py
@@ -17,6 +17,6 @@ if __name__ == "__main__":
     print(f'verified all stateful signatures for structure {sf_structure.hex()}')
 
     if i == len(structures) - 1:
-      sig = shrincs_sign(msg, sk, -1, None)
+      sig = shrincs_sign(msg, sk, None, None)
       assert shrincs_verify(msg, sig, pk)
       print(f'verified stateless signature')


### PR DESCRIPTION
A negative number of previously issued signatures has no meaning, so `state_ctr` was signed only to carry the "sign statelessly" sentinel. Make it unsigned and pass that sentinel as `None`.

- A textbook case for an option type. The parameter is really "a count, or nothing", and the negative half-space was encoding that sum type in band.
- `state_ctr` was the only signed quantity in the spec, so this leaves every declared integer unsigned, which lets a model in SSProve stay close to the spec using only bounded naturals. It also makes Int64 dead in the in-progress typing work.
- No behaviour change: signature vectors are byte-identical to main, including the exhausted-counter fallback and the forced-stateless path.

Note the `0 <= state_ctr` guards are dropped. A negative input is now out of contract rather than a documented fallback, and the typing work enforces the bound at the call boundary.