### PR TITLE
Iterate each WOTS scheme's chains under its own address type

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -812,15 +812,17 @@ As written this would be insecure: Adversaries could forge signatures by finding
 
 ### WOTS Algorithm
 
-Both WOTS schemes make use of the following common hash-chaining algorithm.
+Both WOTS schemes iterate their hash chains the same way, differing only in the `ADRS` type the
+steps are tweaked by. Each scheme therefore has its own chaining function, which sets that type
+itself rather than leaving it to every caller.
 
 
-#### `wots_chain_iter(...)`
+#### `wots_tw_chain_iter(...)`
 
-<!-- DOC START wots_chain_iter -->
-The WOTS hash chain iteration function. Iterates the hash chain from index `start` by `steps`
-steps, returning the node at index `start + steps`. The `ADRS` must be prefilled so the hashes
-are correctly tweaked.
+<!-- DOC START wots_tw_chain_iter -->
+The WOTS-TW hash chain iteration function. Iterates the hash chain from index `start` by `steps`
+steps, returning the node at index `start + steps`. The `ADRS` must be prefilled with the keypair
+and chain the node belongs to.
 
 - Inputs:
   - `node`: a 16-byte hash.
@@ -831,16 +833,46 @@ are correctly tweaked.
 - Output:
   - a 16-byte hash at index `start + steps`.
 
-This function is used in both stateful and stateless paths, and by both the signer and the verifier.
+This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
-def wots_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  ADRS[9] = SL_WOTS_TW_HASH
   for j in range(start, start+steps):
     ADRS[18:22] = j.to_bytes(4)
     node = F(pk_seed, ADRS, node)
   return node
 ```
-<!-- DOC END wots_chain_iter -->
+<!-- DOC END wots_tw_chain_iter -->
+
+
+#### `wots_c_chain_iter(...)`
+
+<!-- DOC START wots_c_chain_iter -->
+The WOTS+C hash chain iteration function. Iterates the hash chain from index `start` by `steps`
+steps, returning the node at index `start + steps`. The `ADRS` must be prefilled with the keypair
+and chain the node belongs to.
+
+- Inputs:
+  - `node`: a 16-byte hash.
+  - `start`: a 32-bit unsigned integer, the index of `node` in its hash chain.
+  - `steps`: a 32-bit unsigned integer, the number of steps to take up the chain; `start + steps` must not exceed `2**32`.
+  - `pk_seed`: a 16-byte salt.
+  - `ADRS`: a 22-byte address.
+- Output:
+  - a 16-byte hash at index `start + steps`.
+
+This function is only used in the stateful path, and by both the signer and the verifier.
+
+```py
+def wots_c_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  ADRS[9] = SF_WOTS_C_HASH
+  for j in range(start, start+steps):
+    ADRS[18:22] = j.to_bytes(4)
+    node = F(pk_seed, ADRS, node)
+  return node
+```
+<!-- DOC END wots_c_chain_iter -->
 
 
 ### WOTS-TW
@@ -967,8 +999,7 @@ def wots_tw_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes
     ADRS[14:18] = i.to_bytes(4) # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
-    ADRS[9] = SL_WOTS_TW_HASH
-    wots_pk[i] = wots_chain_iter(sk, 0, 2**WOTS_TW_CHAIN_BITS - 1, pk_seed, ADRS)
+    wots_pk[i] = wots_tw_chain_iter(sk, 0, 2**WOTS_TW_CHAIN_BITS - 1, pk_seed, ADRS)
 
   ADRS[9] = SL_WOTS_TW_PK
   ADRS[14:22] = zeros(8)
@@ -1003,8 +1034,7 @@ def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray
     ADRS[14:18] = i.to_bytes(4)  # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
-    ADRS[9] = SL_WOTS_TW_HASH
-    signature[i] = wots_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
+    signature[i] = wots_tw_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
   return concat(signature)
 ```
 <!-- DOC END wots_tw_sign -->
@@ -1030,11 +1060,10 @@ This function is only used in the stateless path, and by both the signer and the
 def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   indexes = wots_tw_message_to_indexes(message)
   wots_pk = [b''] * WOTS_TW_CHAIN_COUNT
-  ADRS[9] = SL_WOTS_TW_HASH
   for i in range(WOTS_TW_CHAIN_COUNT):
     ADRS[14:18] = i.to_bytes(4)
     steps = 2**WOTS_TW_CHAIN_BITS - 1 - indexes[i]
-    wots_pk[i] = wots_chain_iter(signature[i*16 : (i+1)*16], indexes[i], steps, pk_seed, ADRS)
+    wots_pk[i] = wots_tw_chain_iter(signature[i*16 : (i+1)*16], indexes[i], steps, pk_seed, ADRS)
 
   ADRS[9] = SL_WOTS_TW_PK
   ADRS[14:22] = zeros(8)
@@ -1149,8 +1178,7 @@ def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
     ADRS[14:18] = i.to_bytes(4) # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
-    ADRS[9] = SF_WOTS_C_HASH
-    wots_pk[i] = wots_chain_iter(sk, 0, 2**WOTS_C_CHAIN_BITS - 1, pk_seed, ADRS)
+    wots_pk[i] = wots_c_chain_iter(sk, 0, 2**WOTS_C_CHAIN_BITS - 1, pk_seed, ADRS)
 
   ADRS[9] = SF_WOTS_C_PK
   ADRS[14:22] = zeros(8)
@@ -1191,8 +1219,7 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
     ADRS[14:18] = i.to_bytes(4)  # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
-    ADRS[9] = SF_WOTS_C_HASH
-    signature[i] = wots_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
+    signature[i] = wots_c_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
   return counter.to_bytes(2) + concat(signature)
 ```
 <!-- DOC END wots_c_sign -->
@@ -1227,12 +1254,11 @@ def wots_c_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: byt
     return None
 
   wots_pk = [b''] * WOTS_C_CHAIN_COUNT
-  ADRS[9] = SF_WOTS_C_HASH
   ADRS[10:14] = zeros(4) # zeros reserved
   for i in range(WOTS_C_CHAIN_COUNT):
     ADRS[14:18] = i.to_bytes(4)
     steps = 2**WOTS_C_CHAIN_BITS - 1 - indexes[i]
-    wots_pk[i] = wots_chain_iter(signature[2+i*16 : 2+(i+1)*16], indexes[i], steps, pk_seed, ADRS)
+    wots_pk[i] = wots_c_chain_iter(signature[2+i*16 : 2+(i+1)*16], indexes[i], steps, pk_seed, ADRS)
 
   ADRS[9] = SF_WOTS_C_PK
   ADRS[14:22] = zeros(8)

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -335,11 +335,11 @@ def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> byte
 
 #  Winternitz algorithms
 
-def wots_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
   """
-  The WOTS hash chain iteration function. Iterates the hash chain from index `start` by `steps`
-  steps, returning the node at index `start + steps`. The `ADRS` must be prefilled so the hashes
-  are correctly tweaked.
+  The WOTS-TW hash chain iteration function. Iterates the hash chain from index `start` by `steps`
+  steps, returning the node at index `start + steps`. The `ADRS` must be prefilled with the keypair
+  and chain the node belongs to.
 
   - Inputs:
     - `node`: a 16-byte hash.
@@ -350,8 +350,32 @@ def wots_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: b
   - Output:
     - a 16-byte hash at index `start + steps`.
 
-  This function is used in both stateful and stateless paths, and by both the signer and the verifier.
+  This function is only used in the stateless path, and by both the signer and the verifier.
   """
+  ADRS[9] = SL_WOTS_TW_HASH
+  for j in range(start, start+steps):
+    ADRS[18:22] = j.to_bytes(4)
+    node = F(pk_seed, ADRS, node)
+  return node
+
+def wots_c_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  """
+  The WOTS+C hash chain iteration function. Iterates the hash chain from index `start` by `steps`
+  steps, returning the node at index `start + steps`. The `ADRS` must be prefilled with the keypair
+  and chain the node belongs to.
+
+  - Inputs:
+    - `node`: a 16-byte hash.
+    - `start`: a 32-bit unsigned integer, the index of `node` in its hash chain.
+    - `steps`: a 32-bit unsigned integer, the number of steps to take up the chain; `start + steps` must not exceed `2**32`.
+    - `pk_seed`: a 16-byte salt.
+    - `ADRS`: a 22-byte address.
+  - Output:
+    - a 16-byte hash at index `start + steps`.
+
+  This function is only used in the stateful path, and by both the signer and the verifier.
+  """
+  ADRS[9] = SF_WOTS_C_HASH
   for j in range(start, start+steps):
     ADRS[18:22] = j.to_bytes(4)
     node = F(pk_seed, ADRS, node)
@@ -412,8 +436,7 @@ def wots_tw_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes
     ADRS[14:18] = i.to_bytes(4) # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
-    ADRS[9] = SL_WOTS_TW_HASH
-    wots_pk[i] = wots_chain_iter(sk, 0, 2**WOTS_TW_CHAIN_BITS - 1, pk_seed, ADRS)
+    wots_pk[i] = wots_tw_chain_iter(sk, 0, 2**WOTS_TW_CHAIN_BITS - 1, pk_seed, ADRS)
 
   ADRS[9] = SL_WOTS_TW_PK
   ADRS[14:22] = zeros(8)
@@ -442,8 +465,7 @@ def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray
     ADRS[14:18] = i.to_bytes(4)  # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
-    ADRS[9] = SL_WOTS_TW_HASH
-    signature[i] = wots_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
+    signature[i] = wots_tw_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
   return concat(signature)
 
 def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
@@ -463,11 +485,10 @@ def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, AD
   """
   indexes = wots_tw_message_to_indexes(message)
   wots_pk = [b''] * WOTS_TW_CHAIN_COUNT
-  ADRS[9] = SL_WOTS_TW_HASH
   for i in range(WOTS_TW_CHAIN_COUNT):
     ADRS[14:18] = i.to_bytes(4)
     steps = 2**WOTS_TW_CHAIN_BITS - 1 - indexes[i]
-    wots_pk[i] = wots_chain_iter(signature[i*16 : (i+1)*16], indexes[i], steps, pk_seed, ADRS)
+    wots_pk[i] = wots_tw_chain_iter(signature[i*16 : (i+1)*16], indexes[i], steps, pk_seed, ADRS)
 
   ADRS[9] = SL_WOTS_TW_PK
   ADRS[14:22] = zeros(8)
@@ -542,8 +563,7 @@ def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
     ADRS[14:18] = i.to_bytes(4) # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
-    ADRS[9] = SF_WOTS_C_HASH
-    wots_pk[i] = wots_chain_iter(sk, 0, 2**WOTS_C_CHAIN_BITS - 1, pk_seed, ADRS)
+    wots_pk[i] = wots_c_chain_iter(sk, 0, 2**WOTS_C_CHAIN_BITS - 1, pk_seed, ADRS)
 
   ADRS[9] = SF_WOTS_C_PK
   ADRS[14:22] = zeros(8)
@@ -578,8 +598,7 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
     ADRS[14:18] = i.to_bytes(4)  # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
-    ADRS[9] = SF_WOTS_C_HASH
-    signature[i] = wots_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
+    signature[i] = wots_c_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
   return counter.to_bytes(2) + concat(signature)
 
 def wots_c_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes, ADRS: bytearray) -> Optional[bytes]:
@@ -605,12 +624,11 @@ def wots_c_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: byt
     return None
 
   wots_pk = [b''] * WOTS_C_CHAIN_COUNT
-  ADRS[9] = SF_WOTS_C_HASH
   ADRS[10:14] = zeros(4) # zeros reserved
   for i in range(WOTS_C_CHAIN_COUNT):
     ADRS[14:18] = i.to_bytes(4)
     steps = 2**WOTS_C_CHAIN_BITS - 1 - indexes[i]
-    wots_pk[i] = wots_chain_iter(signature[2+i*16 : 2+(i+1)*16], indexes[i], steps, pk_seed, ADRS)
+    wots_pk[i] = wots_c_chain_iter(signature[2+i*16 : 2+(i+1)*16], indexes[i], steps, pk_seed, ADRS)
 
   ADRS[9] = SF_WOTS_C_PK
   ADRS[14:22] = zeros(8)


### PR DESCRIPTION
`wots_chain_iter` was shared by both WOTS schemes, and every caller had to set the `ADRS` type flag itself before the call. Give each scheme its own chaining function which sets that flag, so the type belongs to the function owning the chain rather than to its callers. The hashes are unchanged.

This came out of the typing work: one shared chaining function has to accept an ADRS of either scheme's shape, where two functions each take their own. It also removes the caller-side obligation to set the type flag, which a caller could get wrong silently.