### PR TITLE
add context parameter to SHRINCS interface

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -2148,7 +2148,7 @@ TODO: diagrams
 
 #### Contexts
 
-The high-level `shrincs_sign` and `shrincs_verify` functions accept a context parameter `ctx`, which restricts signature validity to within a specific use-case, protocol, or other such zone of specificity. Signatures created by `shrincs_sign` when given a certain `ctx` are invalid if verified using `shrincs_verify` with any other context value. Typically `ctx` is set to some hard-coded constant value, to prevent misuse. For example, if a signer creates a signature with `ctx = b"twitter"`, this signature cannot be replayed with `ctx = b"banking"`.
+The high-level `shrincs_sign` and `shrincs_verify` functions accept a context parameter `ctx`, which restricts signature validity to within a specific use-case, protocol, or other such zone of specificity. Signatures created by `shrincs_sign` when given a certain `ctx` are invalid if verified using `shrincs_verify` with any other context value. Typically `ctx` is set to some hard-coded constant value, to prevent misuse. For example, if a signer creates a signature with `ctx = b"bitcoin-tx"`, this signature cannot be replayed with `ctx = b"auth-challenge"`.
 
 This mirrors the interface of SLH-DSA[^slhdsa], and in fact the stateless signing component passes `ctx` transparently through to the `slh_dsa_sign` and `slh_dsa_verify` functions.
 

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -2146,6 +2146,12 @@ This encoding is chosen such that by slicing off the last 18 bytes (`structure +
 
 TODO: diagrams
 
+#### Contexts
+
+The high-level `shrincs_sign` and `shrincs_verify` functions accept a context parameter `ctx`, which restricts signature validity to within a specific use-case, protocol, or other such zone of specificity. Signatures created by `shrincs_sign` when given a certain `ctx` are invalid if verified using `shrincs_verify` with any other context value. Typically `ctx` is set to some hard-coded constant value, to prevent misuse. For example, if a signer creates a signature with `ctx = b"twitter"`, this signature cannot be replayed with `ctx = b"banking"`.
+
+This mirrors the interface of SLH-DSA[^slhdsa], and in fact the stateless signing component passes `ctx` transparently through to the `slh_dsa_sign` and `slh_dsa_verify` functions.
+
 #### On Managing State
 
 A SHRINCS secret key is not complete without its accompanying state. Every SHRINCS key has a fixed number of stateful signature slots which allow the signer to use compact WOTS+C signatures via the FXMSS (stateful) signing path. As previously discussed in [the section on WOTS](#wots-schemes), reusing a one-time signature keypair within FXMSS to sign distinct messages will break the security of the scheme and permit forgeries. To avoid using the same WOTS+C keypair more than once, signers using FXMSS must track a single integer, called the _state counter._ This counter tracks the number of signatures previously issued by the keypair. It increments once for every stateful FXMSS signature created, and _must never decrement._ When signing the SHRINCS stateful signing algorithm chooses which WOTS+C leaf to use based on the state counter, and the FXMSS tree structure.
@@ -2260,12 +2266,13 @@ def shrincs_sf_leaf_select(structure: bytes, state_ctr: Optional[int]) -> Option
 #### `shrincs_sign(...)`
 
 <!-- DOC START shrincs_sign -->
-The SHRINCS signing function. Signs `message` with the serialized secret key `shrincs_seckey`:
+The SHRINCS signing function. Signs `message` and `ctx` with the serialized secret key `shrincs_seckey`:
 uses the stateful FXMSS path when `state_ctr` is valid for the key's tree structure, otherwise
-falls back to the stateless SLH-DSA path.
+falls back to the stateless SLH-DSA path. Verifiers must use `shrincs_verify` with the same `ctx`.
 
 - Inputs:
   - `message`: a message of at most `2**61 - 128` bytes.
+  - `ctx`: a context of at most 255 bytes.
   - `shrincs_seckey`: an 82-byte SHRINCS secret key.
   - `state_ctr`: a 64-bit unsigned integer, the number of stateful signatures the keypair has
     previously issued, or `None` to sign statelessly.
@@ -2284,7 +2291,7 @@ This function is used only by the signer.
 > non-recoverable storage medium before the signature is returned to the caller.
 
 ```py
-def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int], opt_rand: Optional[bytes]) -> Optional[bytes]:
+def shrincs_sign(message: bytes, ctx: bytes, shrincs_seckey: bytes, state_ctr: Optional[int], opt_rand: Optional[bytes]) -> Optional[bytes]:
   sk_seed      = shrincs_seckey[0:16]
   sk_prf       = shrincs_seckey[16:32]
   pk_seed      = shrincs_seckey[32:48]
@@ -2297,11 +2304,16 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int]
   # Stateless signing path.
   if leaf_position is None:
     # Bind the stateless signature to the stateful keypair.
-    return slh_dsa_sign(sf_root + message, b"", sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
+    return slh_dsa_sign(sf_root + message, ctx, sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
 
   # Stateful signing path.
-  bound_message = sl_root + message # Bind the stateful signature to the stateless keypair
   leaf_index, leaf_height = leaf_position
+
+  # Bind the stateful signature to the stateless keypair and context in the
+  # same manner as the stateless component.
+  assert len(ctx) < 256
+  bound_message = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + sl_root + message
+
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
@@ -2325,7 +2337,8 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int]
 
 <!-- DOC START shrincs_verify -->
 The SHRINCS verification function. Returns true iff `signature` is a valid stateful or stateless
-SHRINCS signature on `message` under `shrincs_pubkey`.
+SHRINCS signature on `message` under `shrincs_pubkey`. Signatures must be produced via
+`shrincs_sign` with the same `ctx`.
 
 The length of `signature` selects the path: exactly `SPHX_SIGNATURE_SIZE` bytes for the
 stateless path, or `SHRINCS_SF_SIGNATURE_SIZE_MIN` to `SHRINCS_SF_SIGNATURE_SIZE_MAX` bytes
@@ -2336,6 +2349,7 @@ and compares the result against the public key.
 - Inputs:
   - `message`: a message of at most `2**61 - 128` bytes.
   - `signature`: a candidate SHRINCS signature, of any length.
+  - `ctx`: a context of at most 255 bytes.
   - `shrincs_pubkey`: a 48-byte SHRINCS public key.
 - Output:
   - a boolean indicating if the signature is valid.
@@ -2343,7 +2357,7 @@ and compares the result against the public key.
 This function is used only by the verifier.
 
 ```py
-def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> bool:
+def shrincs_verify(message: bytes, signature: bytes, ctx: bytes, shrincs_pubkey: bytes) -> bool:
   pk_seed = shrincs_pubkey[0:16]
   sl_root = shrincs_pubkey[16:32]
   sf_root = shrincs_pubkey[32:48]
@@ -2351,7 +2365,7 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
   # Stateless verification path.
   if len(signature) == SPHX_SIGNATURE_SIZE:
     # Stateless signatures must be bound to the stateful keypair.
-    return slh_dsa_verify(sf_root + message, signature, b"", pk_seed, sl_root)
+    return slh_dsa_verify(sf_root + message, signature, ctx, pk_seed, sl_root)
 
   # Stateful verification path. These bounds are the FXMSS bounds plus a 24-byte header.
   elif SHRINCS_SF_SIGNATURE_SIZE_MIN <= len(signature) <= SHRINCS_SF_SIGNATURE_SIZE_MAX:
@@ -2374,8 +2388,12 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
     ADRS[0] = leaf_height
     ADRS[1:9] = leaf_index.to_bytes(8)
 
-    # Stateful signatures must be bound to the stateless keypair.
-    message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, sl_root + message)
+    # Stateful signatures must be bound to the stateless keypair and context
+    # in the same manner as the stateless component.
+    assert len(ctx) < 256
+    bound_message = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + sl_root + message
+
+    message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, bound_message)
     root = fxmss_pubkey_from_sig(leaf_index, fxmss_signature, message_digest, pk_seed)
     if root is None:
       return False

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -1272,14 +1272,15 @@ def shrincs_sf_leaf_select(structure: bytes, state_ctr: Optional[int]) -> Option
   # - no more signatures left
   return None
 
-def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int], opt_rand: Optional[bytes]) -> Optional[bytes]:
+def shrincs_sign(message: bytes, ctx: bytes, shrincs_seckey: bytes, state_ctr: Optional[int], opt_rand: Optional[bytes]) -> Optional[bytes]:
   """
-  The SHRINCS signing function. Signs `message` with the serialized secret key `shrincs_seckey`:
+  The SHRINCS signing function. Signs `message` and `ctx` with the serialized secret key `shrincs_seckey`:
   uses the stateful FXMSS path when `state_ctr` is valid for the key's tree structure, otherwise
-  falls back to the stateless SLH-DSA path.
+  falls back to the stateless SLH-DSA path. Verifiers must use `shrincs_verify` with the same `ctx`.
 
   - Inputs:
     - `message`: a message of at most `2**61 - 128` bytes.
+    - `ctx`: a context of at most 255 bytes.
     - `shrincs_seckey`: an 82-byte SHRINCS secret key.
     - `state_ctr`: a 64-bit unsigned integer, the number of stateful signatures the keypair has
       previously issued, or `None` to sign statelessly.
@@ -1309,11 +1310,16 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int]
   # Stateless signing path.
   if leaf_position is None:
     # Bind the stateless signature to the stateful keypair.
-    return slh_dsa_sign(sf_root + message, b"", sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
+    return slh_dsa_sign(sf_root + message, ctx, sk_seed, sk_prf, pk_seed, sl_root, opt_rand)
 
   # Stateful signing path.
-  bound_message = sl_root + message # Bind the stateful signature to the stateless keypair
   leaf_index, leaf_height = leaf_position
+
+  # Bind the stateful signature to the stateless keypair and context in the
+  # same manner as the stateless component.
+  assert len(ctx) < 256
+  bound_message = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + sl_root + message
+
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
@@ -1328,10 +1334,11 @@ def shrincs_sign(message: bytes, shrincs_seckey: bytes, state_ctr: Optional[int]
   # TODO: compact encoding for leaf index
   return R + leaf_index.to_bytes(8) + fxmss_signature
 
-def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> bool:
+def shrincs_verify(message: bytes, signature: bytes, ctx: bytes, shrincs_pubkey: bytes) -> bool:
   """
   The SHRINCS verification function. Returns true iff `signature` is a valid stateful or stateless
-  SHRINCS signature on `message` under `shrincs_pubkey`.
+  SHRINCS signature on `message` under `shrincs_pubkey`. Signatures must be produced via
+  `shrincs_sign` with the same `ctx`.
 
   The length of `signature` selects the path: exactly `SPHX_SIGNATURE_SIZE` bytes for the
   stateless path, or `SHRINCS_SF_SIGNATURE_SIZE_MIN` to `SHRINCS_SF_SIGNATURE_SIZE_MAX` bytes
@@ -1342,6 +1349,7 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
   - Inputs:
     - `message`: a message of at most `2**61 - 128` bytes.
     - `signature`: a candidate SHRINCS signature, of any length.
+    - `ctx`: a context of at most 255 bytes.
     - `shrincs_pubkey`: a 48-byte SHRINCS public key.
   - Output:
     - a boolean indicating if the signature is valid.
@@ -1355,7 +1363,7 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
   # Stateless verification path.
   if len(signature) == SPHX_SIGNATURE_SIZE:
     # Stateless signatures must be bound to the stateful keypair.
-    return slh_dsa_verify(sf_root + message, signature, b"", pk_seed, sl_root)
+    return slh_dsa_verify(sf_root + message, signature, ctx, pk_seed, sl_root)
 
   # Stateful verification path. These bounds are the FXMSS bounds plus a 24-byte header.
   elif SHRINCS_SF_SIGNATURE_SIZE_MIN <= len(signature) <= SHRINCS_SF_SIGNATURE_SIZE_MAX:
@@ -1378,8 +1386,12 @@ def shrincs_verify(message: bytes, signature: bytes, shrincs_pubkey: bytes) -> b
     ADRS[0] = leaf_height
     ADRS[1:9] = leaf_index.to_bytes(8)
 
-    # Stateful signatures must be bound to the stateless keypair.
-    message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, sl_root + message)
+    # Stateful signatures must be bound to the stateless keypair and context
+    # in the same manner as the stateless component.
+    assert len(ctx) < 256
+    bound_message = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + sl_root + message
+
+    message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, bound_message)
     root = fxmss_pubkey_from_sig(leaf_index, fxmss_signature, message_digest, pk_seed)
     if root is None:
       return False

--- a/impl/test.py
+++ b/impl/test.py
@@ -12,11 +12,11 @@ if __name__ == "__main__":
 
     msg = b"foobar!"
     for j in range(16):
-      sig = shrincs_sign(msg, sk, j, None)
-      assert shrincs_verify(msg, sig, pk)
+      sig = shrincs_sign(msg, b"", sk, j, None)
+      assert shrincs_verify(msg, sig, b"", pk)
     print(f'verified all stateful signatures for structure {sf_structure.hex()}')
 
     if i == len(structures) - 1:
-      sig = shrincs_sign(msg, sk, None, None)
-      assert shrincs_verify(msg, sig, pk)
+      sig = shrincs_sign(msg, b"", sk, None, None)
+      assert shrincs_verify(msg, sig, b"", pk)
       print(f'verified stateless signature')


### PR DESCRIPTION
Fixes #23

This PR changes the SHRINCS sign/verify interface to support context strings a la FIPS-205 SLH-DSA.

On the stateless side, we pass `ctx` directly down to the SLH-DSA functions.

On the stateful side, we prepend the `ctx` before `sl_root` to match the structure of the message signed by the stateless component.