### PR TITLE
H_msg_sf inner collision fix 3: move ADRS[:9] to after inner hash

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -777,7 +777,7 @@ Note that `pk_seed` is not padded in this tweakable hash function.
 
 ```py
 def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes) -> bytes:
-  return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + sf_root + ADRS[:9] + M))
+  return sha256(R + pk_seed + sha256(R + pk_seed + sf_root + ADRS[:9] + M) + ADRS[:9])
 ```
 <!-- DOC END H_msg_sf -->
 

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -293,7 +293,7 @@ def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes
 
   Note that `pk_seed` is not padded in this tweakable hash function.
   """
-  return sha256(R + pk_seed + ADRS[:9] + sha256(R + pk_seed + sf_root + ADRS[:9] + M))
+  return sha256(R + pk_seed + sha256(R + pk_seed + sf_root + ADRS[:9] + M) + ADRS[:9])
 
 def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   """


### PR DESCRIPTION
This is an alternative fix for #30, see also #34 and #35. Moving `ADRS[:9]` to the end of the `H_msg_sf` outer hash call prevents it from being used to grind out a collision between the inner and outer hashes in `H_msg_sf`. Suggested by @error0024 offline.

