### PR TITLE
domain separation for FXMSS trees of different structures

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -477,7 +477,7 @@ Each `ADRS` type gives different contextual meaning to the 12 bytes of the ADRS 
 | `SL_WOTS_TW_HASH` | 4 bytes: key pair index <br> 4 bytes: chain index <br> 4 bytes: hash index | | `SF_WOTS_C_HASH` | 4 bytes: zero padding <br> 4 bytes: chain index <br> 4 bytes: hash index |
 | `SL_WOTS_TW_PK` | 4 bytes: key pair index <br> 8 bytes: zero padding | | `SF_WOTS_C_PK` | 12 bytes: zero padding |
 | `SL_XMSS_TREE` | 4 bytes: zero padding <br> 4 bytes: tree height <br> 4 bytes: tree index | | `SF_FXMSS_TREE` | 12 bytes: zero padding |
-| `SL_FORS_TREE` | 4 bytes: key pair index <br> 4 bytes: tree height <br> 4 bytes: tree index | | `SF_WOTS_C_PRF` | 4 bytes: zero padding <br> 4 bytes: chain index <br> 4 bytes: zero padding |
+| `SL_FORS_TREE` | 4 bytes: key pair index <br> 4 bytes: tree height <br> 4 bytes: tree index | | `SF_WOTS_C_PRF` | 2 bytes: tree structure <br> 2 bytes: zero padding <br> 4 bytes: chain index <br> 4 bytes: zero padding |
 | `SL_FORS_ROOTS` | 4 bytes: key pair index <br> 8 bytes: zero padding | | `SF_WOTS_C_GRIND` | 12 bytes: zero padding |
 | `SL_WOTS_TW_PRF` | 4 bytes: key pair index <br> 4 bytes: chain index <br> 4 bytes: zero padding | | | |
 | `SL_FORS_PRF` | 4 bytes: key pair index <br> 4 bytes: zero padding <br> 4 bytes: tree index | | | |
@@ -1233,12 +1233,12 @@ This function is only used in the stateful path, and only by the signer.
 ```py
 def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   wots_pk = [b''] * WOTS_C_CHAIN_COUNT
-  ADRS[10:14] = zeros(4) # zeros reserved
   for i in range(WOTS_C_CHAIN_COUNT):
     ADRS[9] = SF_WOTS_C_PRF
     ADRS[14:18] = i.to_bytes(4) # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
+    ADRS[10:14] = zeros(4)
     wots_pk[i] = wots_c_chain_iter(sk, 0, 2**WOTS_C_CHAIN_BITS - 1, pk_seed, ADRS)
 
   ADRS[9] = SF_WOTS_C_PK
@@ -1274,12 +1274,12 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
   counter, indexes = grinded
   signature = [b''] * WOTS_C_CHAIN_COUNT
 
-  ADRS[10:14] = zeros(4) # zeros reserved
   for i in range(WOTS_C_CHAIN_COUNT):
     ADRS[9] = SF_WOTS_C_PRF
     ADRS[14:18] = i.to_bytes(4)  # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
+    ADRS[10:14] = zeros(4)
     signature[i] = wots_c_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
   return counter.to_bytes(2) + concat(signature)
 ```
@@ -1722,6 +1722,7 @@ def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes
   if is_uxmss_leaf or is_bxmss_leaf:
     ADRS[0] = node_height
     ADRS[1:9] = node_index.to_bytes(8)
+    ADRS[10:14] = sf_structure + zeros(2)
     return wots_c_pubkey_gen(sk_seed, pk_seed, ADRS)
 
   # Catch and throw if control would enter an infinite recursive loop.
@@ -1778,6 +1779,7 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
+  ADRS[10:14] = sf_structure + zeros(2)
   sig = wots_c_sign(message_digest, sk_seed, pk_seed, ADRS)
   if sig is None:
     return None # practically impossible

--- a/img/adrs-stateful.svg
+++ b/img/adrs-stateful.svg
@@ -211,11 +211,14 @@
 <text x="228.0" y="19.5" text-anchor="middle" style="font-family:Arial, Helvetica, sans-serif;font-size:9px;font-weight:700;fill:#ffffff">21</text>
 <text x="228.0" y="31.5" text-anchor="middle" style="font-family:Arial, Helvetica, sans-serif;font-size:8px;fill:#ffffff;opacity:0.7">1 B</text>
 <rect x="240.0" y="0" width="96.0" height="44" rx="3" fill="#1f1f21" stroke="#3a3a3e" stroke-width="1"/>
+<rect x="240.0" y="0" width="48.0" height="44" rx="3" fill="#33285f" stroke="#8b6fff" stroke-width="1"/>
 <line x1="264.0" y1="2" x2="264.0" y2="42" stroke="#3a3a3e" stroke-width="0.75"/>
 <line x1="288.0" y1="2" x2="288.0" y2="42" stroke="#3a3a3e" stroke-width="0.75"/>
 <line x1="312.0" y1="2" x2="312.0" y2="42" stroke="#3a3a3e" stroke-width="0.75"/>
-<text x="288.0" y="20.5" text-anchor="middle" style="font-family:Arial, Helvetica, sans-serif;font-size:11px;font-weight:400;fill:#8a8e92;font-style:italic">zero padding</text>
-<text x="288.0" y="32.5" text-anchor="middle" style="font-family:Arial, Helvetica, sans-serif;font-size:8px;fill:#8a8e92;opacity:0.7">4 B</text>
+<text x="264.0" y="20.5" text-anchor="middle" style="font-family:Arial, Helvetica, sans-serif;font-size:11px;font-weight:400;fill:#ffffff">structure</text>
+<text x="264.0" y="32.5" text-anchor="middle" style="font-family:Arial, Helvetica, sans-serif;font-size:8px;fill:#8a8e92;opacity:0.7">2 B</text>
+<text x="312.0" y="20.5" text-anchor="middle" style="font-family:Arial, Helvetica, sans-serif;font-size:8px;font-weight:400;fill:#8a8e92;font-style:italic">zero padding</text>
+<text x="312.0" y="32.5" text-anchor="middle" style="font-family:Arial, Helvetica, sans-serif;font-size:8px;fill:#8a8e92;opacity:0.7">2 B</text>
 <rect x="336.0" y="0" width="96.0" height="44" rx="3" fill="#33285f" stroke="#8b6fff" stroke-width="1"/>
 <line x1="360.0" y1="2" x2="360.0" y2="42" stroke="#3a3a3e" stroke-width="0.75"/>
 <line x1="384.0" y1="2" x2="384.0" y2="42" stroke="#3a3a3e" stroke-width="0.75"/>

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -560,12 +560,12 @@ def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   This function is only used in the stateful path, and only by the signer.
   """
   wots_pk = [b''] * WOTS_C_CHAIN_COUNT
-  ADRS[10:14] = zeros(4) # zeros reserved
   for i in range(WOTS_C_CHAIN_COUNT):
     ADRS[9] = SF_WOTS_C_PRF
     ADRS[14:18] = i.to_bytes(4) # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
+    ADRS[10:14] = zeros(4)
     wots_pk[i] = wots_c_chain_iter(sk, 0, 2**WOTS_C_CHAIN_BITS - 1, pk_seed, ADRS)
 
   ADRS[9] = SF_WOTS_C_PK
@@ -595,12 +595,12 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
   counter, indexes = grinded
   signature = [b''] * WOTS_C_CHAIN_COUNT
 
-  ADRS[10:14] = zeros(4) # zeros reserved
   for i in range(WOTS_C_CHAIN_COUNT):
     ADRS[9] = SF_WOTS_C_PRF
     ADRS[14:18] = i.to_bytes(4)  # chain index
     ADRS[18:22] = zeros(4) # zero hash index
     sk = PRF(pk_seed, sk_seed, ADRS)
+    ADRS[10:14] = zeros(4)
     signature[i] = wots_c_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
   return counter.to_bytes(2) + concat(signature)
 
@@ -831,6 +831,7 @@ def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes
   if is_uxmss_leaf or is_bxmss_leaf:
     ADRS[0] = node_height
     ADRS[1:9] = node_index.to_bytes(8)
+    ADRS[10:14] = sf_structure + zeros(2)
     return wots_c_pubkey_gen(sk_seed, pk_seed, ADRS)
 
   # Catch and throw if control would enter an infinite recursive loop.
@@ -881,6 +882,7 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
+  ADRS[10:14] = sf_structure + zeros(2)
   sig = wots_c_sign(message_digest, sk_seed, pk_seed, ADRS)
   if sig is None:
     return None # practically impossible


### PR DESCRIPTION
Fixes #46.

This change modifies how WOTS+C preimages are derived from `PRF`, by adding the `sf_structure` into the ADRS for the `SF_WOTS_C_PRF` ADRS payload.

This ensures that two trees of distinct structures are not cryptographically related to one-another, and in particular this ensures that a UXMSS tree and a BXMSS tree can never share a leaf in common, nor can any two trees of different depths.