### PR TITLE
 Name the ancestor and sibling a climb needs

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -512,6 +512,42 @@ def base_2b(x: bytes, b: int, outlen: int) -> list[int]:
 ```
 <!-- DOC END base_2b -->
 
+#### `sibling_of(...)`
+
+<!-- DOC START sibling_of -->
+Returns the index of the other child of the same parent: the next index up
+from an even node, the previous from an odd one. An odd index is at least
+one, so the difference is never taken below zero, and an even index is below
+the top of its range, so the sum stays in it.
+
+```py
+def sibling_of(node_index: int) -> int:
+  if node_index % 2 == 0:
+    return node_index + 1
+  else:
+    return node_index - 1
+```
+<!-- DOC END sibling_of -->
+
+#### `ancestor_of(...)`
+
+<!-- DOC START ancestor_of -->
+Returns the index of the node `levels` above the node at `node_index`.
+Each layer is half as wide as the one below it, so climbing a level halves the
+index, and an index halved past zero stays there. The result is
+`node_index // 2**levels`, but not computed that way: `levels` reaches
+`FXMSS_HEIGHT`, past the width of the index it climbs, where languages differ
+on what a shift that far means.
+
+```py
+def ancestor_of(node_index: int, levels: int) -> int:
+  for _ in range(levels):
+    node_index = node_index // 2
+
+  return node_index
+```
+<!-- DOC END ancestor_of -->
+
 
 ### Building Blocks
 
@@ -1569,7 +1605,9 @@ This means the interfaces of both XMSS and FXMSS are slightly different, and thi
 >
 > The index counts nodes from the left within a layer, starting at zero.
 > The node at height `h` and index `i` has child nodes at indexes `2*i` (left) and `2*i + 1` (right) at height `h - 1`.
-> Conversely, the ancestor of that node `j` layers above it has index `i >> j`, and the sibling of that ancestor has index `(i >> j) ^ 1`.
+> Conversely, the ancestor of that node `j` layers above it has index `i // 2**j`, and the sibling of that ancestor is the neighboring index: one higher when `i // 2**j` is even, one lower when it is odd.
+> The algorithms climb one level per step, halving the index each time, and so reach the same node without ever forming `2**j`.
+> On the stateful path `j` runs past the width of any register an implementation would hold the index in, and there it MUST NOT compute the ancestor with a single shift by `j`.
 >
 > More specifically for the different merkle tree constructions of XMSS, FXMSS, and FORS:
 >
@@ -1669,7 +1707,7 @@ def xmss_sign(
 
   # Append the Merkle authentication path.
   for j in range(SPHX_XMSS_HEIGHT):
-    sibling_index = (keypair_index >> j) ^ 1
+    sibling_index = sibling_of(ancestor_of(keypair_index, j))
     sig += xmss_node(sk_seed, sibling_index, j, pk_seed, ADRS)
 
   return sig
@@ -1714,9 +1752,9 @@ def xmss_pubkey_from_sig(
 
   for k in range(SPHX_XMSS_HEIGHT):
     ADRS[14:18] = (k + 1).to_bytes(4)
-    ADRS[18:22] = (keypair_index >> (k+1)).to_bytes(4)
+    ADRS[18:22] = ancestor_of(keypair_index, k + 1).to_bytes(4)
     sibling = xmss_auth[k*16 : (k+1)*16]
-    if (keypair_index >> k) & 1 == 1:
+    if ancestor_of(keypair_index, k) % 2 == 1:
       node = H(pk_seed, ADRS, sibling + node)
     else:
       node = H(pk_seed, ADRS, node + sibling)
@@ -2072,7 +2110,7 @@ def fxmss_sign(
 
   # Append the Merkle authentication path.
   for j in range(leaf_depth):
-    sibling_index = (leaf_index >> j) ^ 1
+    sibling_index = sibling_of(ancestor_of(leaf_index, j))
     sibling_height = leaf_height + j
     sig += fxmss_node(sk_seed, sibling_index, sibling_height, pk_seed, tree_balanced, tree_depth, ADRS)
 
@@ -2133,9 +2171,9 @@ def fxmss_pubkey_from_sig(
 
   for k in range(leaf_depth):
     ADRS[0] += 1
-    ADRS[1:9] = (leaf_index >> (k+1)).to_bytes(8)
+    ADRS[1:9] = ancestor_of(leaf_index, k + 1).to_bytes(8)
     sibling = xmss_auth[k*16 : (k+1)*16]
-    if (leaf_index >> k) & 1 == 1:
+    if ancestor_of(leaf_index, k) % 2 == 1:
       node = H(pk_seed, ADRS, sibling + node)
     else:
       node = H(pk_seed, ADRS, node + sibling)
@@ -2291,7 +2329,7 @@ def fors_sign(
     leaf_index = i * 2**SPHX_FORS_HEIGHT + index_set[i]
     sig += fors_sk_gen(sk_seed, pk_seed, ADRS, leaf_index)
     for j in range(SPHX_FORS_HEIGHT):
-      sibling_index = i * 2**(SPHX_FORS_HEIGHT - j) + ((index_set[i] >> j) ^ 1)
+      sibling_index = i * 2**(SPHX_FORS_HEIGHT - j) + sibling_of(ancestor_of(index_set[i], j))
       sig += fors_node(sk_seed, sibling_index, j, pk_seed, ADRS)
   return sig
 ```
@@ -2337,12 +2375,12 @@ def fors_pubkey_from_sig(
     node = F(pk_seed, ADRS, preimage)
     for j in range(SPHX_FORS_HEIGHT):
       ADRS[14:18] = (j + 1).to_bytes(4)
-      ADRS[18:22] = (tree_index >> (j+1)).to_bytes(4)
+      ADRS[18:22] = ancestor_of(tree_index, j + 1).to_bytes(4)
 
       sibling = signature[offset : offset+16]
       offset += 16
 
-      if (index_set[i] >> j) & 1 == 1:
+      if ancestor_of(index_set[i], j) % 2 == 1:
         node = H(pk_seed, ADRS, sibling + node)
       else:
         node = H(pk_seed, ADRS, node + sibling)

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -424,6 +424,37 @@ To save computational effort, `PK.seed` is padded with zero bytes to a length of
 This aligns with the SHA256 block size, so that `PK.seed` can be absorbed into the SHA256 state, and that midstate can be cached & reused.
 
 
+### Value Types
+
+A function signature states the size of each value it takes and returns, in the notation below.
+`impl/shrincs.py` declares that notation as [`typing.Annotated`](https://docs.python.org/3/library/typing.html#typing.Annotated) metadata, so that it can be checked mechanically.
+They are inert in the implementation, and the sizes they state are requirements on any implementation.
+
+- `Bytes[n]` is a byte string of exactly `n` bytes.
+  `n` may be an arithmetic expression over the constants this document defines, evaluated for the parameter set in force, as in `Bytes[2 + WOTS_C_CHAINS_SIZE]`.
+- `Bytes[a:b]` is a byte string of at least `a` and at most `b` bytes.
+  Both bounds are inclusive, unlike a Python slice.
+  Either may be omitted: `Bytes[a:]` is at least `a` bytes, and `Bytes[:b]` at most `b`.
+- A bare `bytes` is bounded only by its callers.
+- `UInt8`, `UInt16`, `UInt32` and `UInt64` are integers in the ranges `[0, 2**8)`, `[0, 2**16)`, `[0, 2**32)` and `[0, 2**64)` respectively, serialized as described in [Utilities](#utilities).
+  A bare `int` is an integer of unbounded width, and no value in this specification is negative.
+- `Array[T, n]` is a sequence of exactly `n` values of type `T`.
+  `n` may be an arithmetic expression over the constants this document defines, as it may in `Bytes[n]`.
+- `list[T]` is a sequence of values of type `T`, as many of them as the paragraph beneath the signature states.
+- `tuple[...]` is a fixed group of values of the given types, in that order, returned by the functions which produce more than one.
+  Each element is written into the field its caller gives it, so the group has no size of its own.
+- `Union[T, U]` is a value of one of the given types.
+  Where this specification returns one, its length tells the reader which.
+- `Optional[T]` is either a `T` or the absence of one.
+- `bool` is true or false, and is never serialized.
+- `bytearray` is the 22-byte address described under [ADRS](#adrs).
+  It is the one value a function modifies in place, which is why it is not given a size here.
+
+These sizes are normative.
+A value is written into a field wide enough to hold it.
+Writing one into a narrower field is an error rather than a value reduced to fit, and every field this specification writes is wide enough for every value which can reach it.
+
+
 ### Utilities
 
 We make use of the following utility helper functions in specifying SHRINCS.

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -1956,14 +1956,16 @@ These algorithms are used only for the stateful FXMSS sub-scheme.
 
 <!-- DOC START fxmss_node -->
 The FXMSS internal node computation function. Recursively computes the FXMSS node at the given
-`node_index` and `node_height` for the tree `sf_structure`.
+`node_index` and `node_height` for a tree of the given shape and depth.
 
 - Inputs:
   - `sk_seed`: a 16-byte secret.
   - `node_index`: a 64-bit unsigned integer, the index (from the left) of the node in the FXMSS layer.
   - `node_height`: an 8-bit unsigned integer, the height (from the bottom) of the node in the FXMSS tree.
   - `pk_seed`: a 16-byte salt.
-  - `sf_structure`: a 2-byte identifier describing the FXMSS tree structure.
+  - `tree_balanced`: a boolean, true for a balanced (BXMSS) tree and false for an
+    unbalanced (UXMSS) tree.
+  - `tree_depth`: an 8-bit unsigned integer, the depth of the FXMSS tree.
   - `ADRS`: a 22-byte address.
 - Output:
   - a 16-byte FXMSS node hash.
@@ -1976,32 +1978,36 @@ def fxmss_node(
     node_index: UInt64,
     node_height: UInt8,
     pk_seed: Bytes[16],
-    sf_structure: Bytes[2],
+    tree_balanced: bool,
+    tree_depth: UInt8,
     ADRS: bytearray,
 ) -> Bytes[16]:
   node_depth = FXMSS_HEIGHT - node_height
-  tree_shape, tree_depth = sf_structure[0], sf_structure[1]
 
-  is_uxmss_leaf = tree_shape == FXMSS_SHAPE_UNBALANCED and (node_index == 1 or node_depth == tree_depth)
-  is_bxmss_leaf = tree_shape == FXMSS_SHAPE_BALANCED and node_depth == tree_depth
+  is_uxmss_leaf = not tree_balanced and (node_index == 1 or node_depth == tree_depth)
+  is_bxmss_leaf = tree_balanced and node_depth == tree_depth
 
   if is_uxmss_leaf or is_bxmss_leaf:
+    if tree_balanced:
+      tree_shape = FXMSS_SHAPE_BALANCED
+    else:
+      tree_shape = FXMSS_SHAPE_UNBALANCED
     ADRS[0] = node_height
     ADRS[1:9] = node_index.to_bytes(8)
-    ADRS[10:14] = sf_structure + zeros(2)
+    ADRS[10:14] = tree_shape.to_bytes(1) + tree_depth.to_bytes(1) + zeros(2)
     return wots_c_pubkey_gen(sk_seed, pk_seed, ADRS)
 
   # Catch and throw if control would enter an infinite recursive loop.
-  if tree_shape == FXMSS_SHAPE_UNBALANCED:
-    assert node_index == 0
-  elif tree_shape == FXMSS_SHAPE_BALANCED:
+  if tree_balanced:
     assert node_depth < tree_depth
+  else:
+    assert node_index == 0
 
   # Recursively derive the left/right child nodes.
   lchild_index = 2 * node_index
   child_height = node_height - 1
-  lchild = fxmss_node(sk_seed, lchild_index, child_height, pk_seed, sf_structure, ADRS)
-  rchild = fxmss_node(sk_seed, lchild_index + 1, child_height, pk_seed, sf_structure, ADRS)
+  lchild = fxmss_node(sk_seed, lchild_index, child_height, pk_seed, tree_balanced, tree_depth, ADRS)
+  rchild = fxmss_node(sk_seed, lchild_index + 1, child_height, pk_seed, tree_balanced, tree_depth, ADRS)
 
   # Compute and return the parent node.
   ADRS[0] = node_height
@@ -2025,7 +2031,9 @@ The FXMSS signing function. Produces a deterministic WOTS+C signature at the lea
   - `leaf_index`: a 64-bit unsigned integer, the index (from the left) of the signing leaf in the FXMSS layer.
   - `leaf_height`: an 8-bit unsigned integer, the height (from the bottom) of the signing leaf in the FXMSS tree.
   - `pk_seed`: a 16-byte salt.
-  - `sf_structure`: a 2-byte identifier describing the FXMSS tree structure.
+  - `tree_balanced`: a boolean, true for a balanced (BXMSS) tree and false for an
+    unbalanced (UXMSS) tree.
+  - `tree_depth`: an 8-bit unsigned integer, the depth of the FXMSS tree.
 - Output:
   - a `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT - leaf_height)`-byte signature, or null.
 
@@ -2038,21 +2046,26 @@ def fxmss_sign(
     leaf_index: UInt64,
     leaf_height: UInt8,
     pk_seed: Bytes[16],
-    sf_structure: Bytes[2],
+    tree_balanced: bool,
+    tree_depth: UInt8,
 ) -> Optional[Bytes[FXMSS_SIGNATURE_SIZE_MIN:FXMSS_SIGNATURE_SIZE_MAX]]:
   leaf_depth = FXMSS_HEIGHT - leaf_height
 
   # Validate the leaf is positioned correctly for the specified tree structure.
-  tree_shape, tree_depth = sf_structure[0], sf_structure[1]
-  if tree_shape == FXMSS_SHAPE_UNBALANCED:
-    assert leaf_index == 1 or leaf_depth == tree_depth
-  if tree_shape == FXMSS_SHAPE_BALANCED:
+  if tree_balanced:
     assert leaf_depth == tree_depth
+  else:
+    assert leaf_index == 1 or leaf_depth == tree_depth
+
+  if tree_balanced:
+    tree_shape = FXMSS_SHAPE_BALANCED
+  else:
+    tree_shape = FXMSS_SHAPE_UNBALANCED
 
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
-  ADRS[10:14] = sf_structure + zeros(2)
+  ADRS[10:14] = tree_shape.to_bytes(1) + tree_depth.to_bytes(1) + zeros(2)
   sig = wots_c_sign(message_digest, sk_seed, pk_seed, ADRS)
   if sig is None:
     return None # practically impossible
@@ -2061,7 +2074,7 @@ def fxmss_sign(
   for j in range(leaf_depth):
     sibling_index = (leaf_index >> j) ^ 1
     sibling_height = leaf_height + j
-    sig += fxmss_node(sk_seed, sibling_index, sibling_height, pk_seed, sf_structure, ADRS)
+    sig += fxmss_node(sk_seed, sibling_index, sibling_height, pk_seed, tree_balanced, tree_depth, ADRS)
 
   return sig
 ```
@@ -2603,7 +2616,9 @@ and the stateful tree `sf_structure`.
 
 - Inputs:
   - `seed`: a 48-byte random seed. Must be sampled from a CSRNG.
-  - `sf_structure`: a 2-byte identifier describing the shape and depth of the stateful FXMSS tree.
+  - `sf_structure`: a 2-byte identifier describing the FXMSS tree structure: a shape byte, which
+    must be one of the `FXMSS_SHAPE_*` values, followed by a depth byte. See the recommended
+    depths for each shape in [Tree Shapes](#tree-shapes).
 - Outputs:
   - an 82-byte SHRINCS secret key.
   - a 48-byte SHRINCS public key.
@@ -2611,14 +2626,16 @@ and the stateful tree `sf_structure`.
 This function is used only during key generation.
 
 > [!WARNING]
-> The `sf_structure` argument must come from a trusted source or else be validated.
-> If an adversary can control `sf_structure` they may cause key-generation to fail, or hang
-> consuming compute resources by making the implementation generate a very large BXMSS tree.
+> The `sf_structure` argument must come from a trusted source or else be validated. If an
+> adversary can control it they may cause key-generation to fail, or hang consuming compute
+> resources: a balanced tree of depth `sf_structure[1]` costs `2**sf_structure[1]` WOTS+C key
+> generations, so implementations SHOULD reject a depth they cannot afford to compute.
 
 ```py
 def shrincs_keygen(seed: Bytes[48], sf_structure: Bytes[2]) -> tuple[Bytes[82], Bytes[48]]:
   assert len(seed) == 48
   assert len(sf_structure) == 2
+  assert sf_structure[0] == FXMSS_SHAPE_UNBALANCED or sf_structure[0] == FXMSS_SHAPE_BALANCED
 
   sk_seed = seed[0:16]
   sk_prf  = seed[16:32]
@@ -2627,7 +2644,8 @@ def shrincs_keygen(seed: Bytes[48], sf_structure: Bytes[2]) -> tuple[Bytes[82], 
   ADRS = bytearray(22)
   ADRS[0] = SPHX_LAYER_COUNT - 1
   sl_root = xmss_node(sk_seed, 0, SPHX_XMSS_HEIGHT, pk_seed, ADRS)
-  sf_root = fxmss_node(sk_seed, 0, FXMSS_HEIGHT, pk_seed, sf_structure, bytearray(22))
+  tree_balanced = sf_structure[0] == FXMSS_SHAPE_BALANCED
+  sf_root = fxmss_node(sk_seed, 0, FXMSS_HEIGHT, pk_seed, tree_balanced, sf_structure[1], bytearray(22))
 
   shrincs_seckey = sk_seed + sk_prf + pk_seed + sl_root + sf_structure + sf_root
   shrincs_pubkey = pk_seed + sl_root + sf_root
@@ -2752,7 +2770,8 @@ def shrincs_sign(
 
   # Bind the stateful signature to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, bound_message)
-  fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, sf_structure)
+  tree_balanced = sf_structure[0] == FXMSS_SHAPE_BALANCED
+  fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, tree_balanced, sf_structure[1])
   if fxmss_signature is None:
     return None # practically impossible
 

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -1597,6 +1597,7 @@ This function is only used in the stateless path, and only by the signer.
 
 ```py
 def xmss_sign(message: bytes, sk_seed: bytes, keypair_index: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+  # Sign the message with WOTS-TW.
   ADRS[10:14] = keypair_index.to_bytes(4)
   sig = wots_tw_sign(message, sk_seed, pk_seed, ADRS)
 

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -619,7 +619,7 @@ The `sha256` hash function.
   - a 32-byte hash.
 
 ```py
-def sha256(message: bytes) -> bytes:
+def sha256(message: Bytes[:2**61 - 1]) -> Bytes[32]:
   return hashlib.sha256(bytes(message)).digest()
 ```
 <!-- DOC END sha256 -->
@@ -654,7 +654,7 @@ single 16-byte hash.
 This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
-def T_sl(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
+def T_sl(pk_seed: Bytes[16], ADRS: bytearray, M_l: Bytes[WOTS_TW_CHAINS_SIZE]) -> Bytes[16]:
   return sha256(pk_seed + zeros(48) + ADRS + M_l)[:16]
 ```
 <!-- DOC END T_sl -->
@@ -676,7 +676,7 @@ single 16-byte hash.
 This function is only used in the stateful path, and by both the signer and the verifier.
 
 ```py
-def T_sf(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
+def T_sf(pk_seed: Bytes[16], ADRS: bytearray, M_l: Bytes[WOTS_C_CHAINS_SIZE]) -> Bytes[16]:
   return sha256(pk_seed + zeros(48) + ADRS + M_l)[:16]
 ```
 <!-- DOC END T_sf -->
@@ -698,7 +698,7 @@ The `T_k` tweaked hash function. Compresses `SPHX_FORS_COUNT` FORS tree roots in
 This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
-def T_k(pk_seed: bytes, ADRS: bytearray, M_k: bytes) -> bytes:
+def T_k(pk_seed: Bytes[16], ADRS: bytearray, M_k: Bytes[SPHX_FORS_COUNT * 16]) -> Bytes[16]:
   return sha256(pk_seed + zeros(48) + ADRS + M_k)[:16]
 ```
 <!-- DOC END T_k -->
@@ -720,7 +720,7 @@ hash chains and to hash FORS leaves.
 This function is used in both stateful and stateless paths, and by both the signer and the verifier.
 
 ```py
-def F(pk_seed: bytes, ADRS: bytearray, M_1: bytes) -> bytes:
+def F(pk_seed: Bytes[16], ADRS: bytearray, M_1: Bytes[16]) -> Bytes[16]:
   return sha256(pk_seed + zeros(48) + ADRS + M_1)[:16]
 ```
 <!-- DOC END F -->
@@ -742,7 +742,7 @@ parent, building the Merkle trees in XMSS and FORS.
 This function is used in both stateful and stateless paths, and by both the signer and the verifier.
 
 ```py
-def H(pk_seed: bytes, ADRS: bytearray, M_2: bytes) -> bytes:
+def H(pk_seed: Bytes[16], ADRS: bytearray, M_2: Bytes[32]) -> Bytes[16]:
   return sha256(pk_seed + zeros(48) + ADRS + M_2)[:16]
 ```
 <!-- DOC END H -->
@@ -765,7 +765,7 @@ constant-sum message space for WOTS+C.
 This function is only used in the stateful path, and by both the signer and the verifier.
 
 ```py
-def H_grind(pk_seed: bytes, ADRS: bytearray, digest: bytes, counter: int) -> bytes:
+def H_grind(pk_seed: Bytes[16], ADRS: bytearray, digest: Bytes[32], counter: UInt16) -> Bytes[16]:
   assert counter <= 0xFFFF
   return sha256(pk_seed + zeros(48) + ADRS[:10] + digest + zeros(4) + counter.to_bytes(2))[:16]
 ```
@@ -797,7 +797,7 @@ The `hmac_sha256` keyed hash function.
   - a 32-byte hash.
 
 ```py
-def hmac_sha256(key: bytes, message: bytes) -> bytes:
+def hmac_sha256(key: Bytes[:64], message: Bytes[:2**61 - 1 - 64]) -> Bytes[32]:
   assert len(key) <= 64
   padded_key = key + zeros(64 - len(key))
   inner = sha256(xor(padded_key, replicate(0x36, 64)) + message)
@@ -822,7 +822,7 @@ and key generation.
 This function is used in both stateful and stateless paths, but only by the signer.
 
 ```py
-def PRF(pk_seed: bytes, sk_seed: bytes, ADRS: bytearray) -> bytes:
+def PRF(pk_seed: Bytes[16], sk_seed: Bytes[16], ADRS: bytearray) -> Bytes[16]:
   return sha256(pk_seed + zeros(48) + ADRS + sk_seed)[:16]
 ```
 <!-- DOC END PRF -->
@@ -853,7 +853,7 @@ or a 16-byte salt sampled from a secure RNG (the "hedged variant" of SLH-DSA, wh
 resistance to side-channel attacks).
 
 ```py
-def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
+def PRF_msg_sl(sk_prf: Bytes[16], opt_rand: Bytes[16], M: bytes) -> Bytes[16]:
   return hmac_sha256(key=sk_prf, message=opt_rand + M)[:16]
 ```
 <!-- DOC END PRF_msg_sl -->
@@ -876,7 +876,7 @@ HMAC-SHA256.
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> bytes:
+def PRF_msg_sf(sk_prf: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray, M: bytes) -> Bytes[16]:
   return hmac_sha256(key=sk_prf + replicate(0xFF, 48), message=pk_seed + ADRS[:9] + M)[:16]
 ```
 <!-- DOC END PRF_msg_sf -->
@@ -915,7 +915,7 @@ This function is only used in the stateless path, and by both the signer and the
 Note that `pk_seed` is not padded in this keyed hash function.
 
 ```py
-def H_msg_sl(R: bytes, pk_seed: bytes, sl_root: bytes, M: bytes) -> bytes:
+def H_msg_sl(R: Bytes[16], pk_seed: Bytes[16], sl_root: Bytes[16], M: bytes) -> Bytes[32]:
   return sha256(R + pk_seed + sha256(R + pk_seed + sl_root + M) + zeros(4))
 ```
 <!-- DOC END H_msg_sl -->
@@ -942,7 +942,9 @@ This function is only used in the stateful path, and by both the signer and the 
 Note that `pk_seed` is not padded in this tweakable hash function.
 
 ```py
-def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes) -> bytes:
+def H_msg_sf(
+    R: Bytes[16], pk_seed: Bytes[16], sf_root: Bytes[16], ADRS: bytearray, M: bytes
+) -> Bytes[32]:
   return sha256(R + pk_seed + sha256(R + pk_seed + sf_root + ADRS[:9] + M) + ADRS[:9])
 ```
 <!-- DOC END H_msg_sf -->
@@ -1028,9 +1030,10 @@ and chain the node belongs to.
 
 - Inputs:
   - `node`: a 16-byte hash.
-  - `start`: a 32-bit unsigned integer, the index of `node` in its hash chain.
-  - `steps`: a 32-bit unsigned integer, the number of steps to take up the chain; `start + steps` must
-    not exceed `2**WOTS_TW_CHAIN_BITS - 1`.
+  - `start`: an 8-bit unsigned integer, the index of `node` in its hash chain, less than
+    `2**WOTS_TW_CHAIN_BITS`.
+  - `steps`: an 8-bit unsigned integer, the number of steps to take up the chain; `start + steps`
+    must not exceed `2**WOTS_TW_CHAIN_BITS - 1`.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
@@ -1039,7 +1042,9 @@ and chain the node belongs to.
 This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
-def wots_tw_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_chain_iter(
+    node: Bytes[16], start: UInt8, steps: UInt8, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   ADRS[9] = SL_WOTS_TW_HASH
   for j in range(start, start+steps):
     ADRS[18:22] = j.to_bytes(4)
@@ -1058,9 +1063,10 @@ and chain the node belongs to.
 
 - Inputs:
   - `node`: a 16-byte hash.
-  - `start`: a 32-bit unsigned integer, the index of `node` in its hash chain.
-  - `steps`: a 32-bit unsigned integer, the number of steps to take up the chain; `start + steps` must
-    not exceed `2**WOTS_C_CHAIN_BITS - 1`.
+  - `start`: an 8-bit unsigned integer, the index of `node` in its hash chain, less than
+    `2**WOTS_C_CHAIN_BITS`.
+  - `steps`: an 8-bit unsigned integer, the number of steps to take up the chain; `start + steps`
+    must not exceed `2**WOTS_C_CHAIN_BITS - 1`.
   - `pk_seed`: a 16-byte salt.
   - `ADRS`: a 22-byte address.
 - Output:
@@ -1069,7 +1075,9 @@ and chain the node belongs to.
 This function is only used in the stateful path, and by both the signer and the verifier.
 
 ```py
-def wots_c_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_c_chain_iter(
+    node: Bytes[16], start: UInt8, steps: UInt8, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   ADRS[9] = SF_WOTS_C_HASH
   for j in range(start, start+steps):
     ADRS[18:22] = j.to_bytes(4)
@@ -1117,7 +1125,7 @@ The WOTS-TW message map function. Converts a 16-byte `message` into a checksumme
 This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
-def wots_tw_message_to_indexes(message: bytes) -> list[int]:
+def wots_tw_message_to_indexes(message: Bytes[16]) -> Array[UInt16, WOTS_TW_CHAIN_COUNT]:
   msg_indexes = base_2b(message, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT1)
   checksum = WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)
 
@@ -1135,7 +1143,7 @@ Alternative implementation, equivalent to `wots_tw_message_to_indexes` but using
 more complex FIPS-205 algorithm.
 
 ```py
-def wots_tw_message_to_indexes_alt(message: bytes) -> list[int]:
+def wots_tw_message_to_indexes_alt(message: Bytes[16]) -> Array[UInt16, WOTS_TW_CHAIN_COUNT]:
   SPHX_WOTS_CHECKSUM_SHIFT = (8 - (WOTS_TW_CHAIN_BITS * WOTS_TW_CHAIN_COUNT2) % 8) % 8
   SPHX_WOTS_CHECKSUM_BYTE_LEN = ceildiv(WOTS_TW_CHAIN_COUNT2 * WOTS_TW_CHAIN_BITS, 8)
   msg_indexes = base_2b(message, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT1)
@@ -1200,7 +1208,7 @@ keypair location prefilled in `ADRS`.
 This function is only used in the stateless path, and only by the signer.
 
 ```py
-def wots_tw_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_pubkey_gen(sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray) -> Bytes[16]:
   wots_pk = [b''] * WOTS_TW_CHAIN_COUNT
   for i in range(WOTS_TW_CHAIN_COUNT):
     ADRS[9] = SL_WOTS_TW_PRF
@@ -1234,7 +1242,9 @@ location prefilled in `ADRS`.
 This function is only used in the stateless path, and only by the signer.
 
 ```py
-def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_sign(
+    message: Bytes[16], sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[WOTS_TW_CHAINS_SIZE]:
   indexes = wots_tw_message_to_indexes(message)
   signature = [b''] * WOTS_TW_CHAIN_COUNT
   for i in range(WOTS_TW_CHAIN_COUNT):
@@ -1265,7 +1275,9 @@ The WOTS-TW verification function. Recovers a WOTS-TW public key from a `signatu
 This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
-def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_pubkey_from_sig(
+    signature: Bytes[WOTS_TW_CHAINS_SIZE], message: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   indexes = wots_tw_message_to_indexes(message)
   wots_pk = [b''] * WOTS_TW_CHAIN_COUNT
   for i in range(WOTS_TW_CHAIN_COUNT):
@@ -1325,7 +1337,9 @@ constant-sum index set, returning the lowest such counter and its index set.
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: bytearray) -> Optional[tuple[int, list[int]]]:
+def wots_c_grind_to_constant_sum(
+    pk_seed: Bytes[16], message_digest: Bytes[32], ADRS: bytearray
+) -> Optional[tuple[UInt16, Array[UInt16, WOTS_C_CHAIN_COUNT]]]:
   ADRS[9] = SF_WOTS_C_GRIND
   for i in range(2**16):
     hashed = H_grind(pk_seed, ADRS, message_digest, i)
@@ -1361,7 +1375,9 @@ constant-sum index set it yields, or null if the counter is invalid.
 This function is only used in the stateful path, and only by the verifier.
 
 ```py
-def wots_c_map_digest(pk_seed: bytes, message_digest: bytes, ADRS: bytearray, counter: int) -> Optional[list[int]]:
+def wots_c_map_digest(
+    pk_seed: Bytes[16], message_digest: Bytes[32], ADRS: bytearray, counter: UInt16
+) -> Optional[Array[UInt16, WOTS_C_CHAIN_COUNT]]:
   ADRS[9] = SF_WOTS_C_GRIND
   hashed = H_grind(pk_seed, ADRS, message_digest, counter)
   indexes = base_2b(hashed, WOTS_C_CHAIN_BITS, WOTS_C_CHAIN_COUNT)
@@ -1389,7 +1405,7 @@ location prefilled in `ADRS`.
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_c_pubkey_gen(sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray) -> Bytes[16]:
   wots_pk = [b''] * WOTS_C_CHAIN_COUNT
   sf_structure = ADRS[10:12]
   for i in range(WOTS_C_CHAIN_COUNT):
@@ -1426,7 +1442,9 @@ keypair location prefilled in `ADRS`.
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> Optional[bytes]:
+def wots_c_sign(
+    message_digest: Bytes[32], sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray
+) -> Optional[Bytes[2 + WOTS_C_CHAINS_SIZE]]:
   grinded = wots_c_grind_to_constant_sum(pk_seed, message_digest, ADRS)
   if grinded is None:
     return None # practically impossible
@@ -1468,7 +1486,12 @@ The WOTS+C verification function. Recovers a WOTS+C public key from a `signature
 This function is only used in the stateful path, and only by the verifier.
 
 ```py
-def wots_c_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes, ADRS: bytearray) -> Optional[bytes]:
+def wots_c_pubkey_from_sig(
+    signature: Bytes[2 + WOTS_C_CHAINS_SIZE],
+    message_digest: Bytes[32],
+    pk_seed: Bytes[16],
+    ADRS: bytearray,
+) -> Optional[Bytes[16]]:
   counter = int.from_bytes(signature[0:2])
   indexes = wots_c_map_digest(pk_seed, message_digest, ADRS, counter)
 
@@ -1587,7 +1610,9 @@ in the hypertree to ensure the hashes are properly tweaked.
 This function is only used in the stateless path, and only by the signer.
 
 ```py
-def xmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def xmss_node(
+    sk_seed: Bytes[16], node_index: UInt32, node_height: UInt32, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   if node_height == 0: # Bottom layer: return the WOTS-TW pubkey hash.
     ADRS[10:14] = node_index.to_bytes(4)
     return wots_tw_pubkey_gen(sk_seed, pk_seed, ADRS)
@@ -1627,7 +1652,9 @@ the location of the XMSS tree in the hypertree to ensure the hashes are properly
 This function is only used in the stateless path, and only by the signer.
 
 ```py
-def xmss_sign(message: bytes, sk_seed: bytes, keypair_index: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def xmss_sign(
+    message: Bytes[16], sk_seed: Bytes[16], keypair_index: UInt32, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[SPHX_XMSS_SIGNATURE_SIZE]:
   # Sign the message with WOTS-TW.
   ADRS[10:14] = keypair_index.to_bytes(4)
   sig = wots_tw_sign(message, sk_seed, pk_seed, ADRS)
@@ -1661,7 +1688,13 @@ hypertree to ensure the hashes are properly tweaked.
 This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
-def xmss_pubkey_from_sig(keypair_index: int, signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def xmss_pubkey_from_sig(
+    keypair_index: UInt32,
+    signature: Bytes[SPHX_XMSS_SIGNATURE_SIZE],
+    message: Bytes[16],
+    pk_seed: Bytes[16],
+    ADRS: bytearray,
+) -> Bytes[16]:
   wots_sig = signature[0 : WOTS_TW_CHAINS_SIZE]
   xmss_auth = signature[WOTS_TW_CHAINS_SIZE : SPHX_XMSS_SIGNATURE_SIZE]
 
@@ -1721,7 +1754,13 @@ The hypertree signing function. Signs a 16-byte `message` through a hypertree of
 This function is only used in the stateless path, and only by the signer.
 
 ```py
-def hypertree_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, tree_index: int, leaf_index: int) -> bytes:
+def hypertree_sign(
+    message: Bytes[16],
+    sk_seed: Bytes[16],
+    pk_seed: Bytes[16],
+    tree_index: UInt64,
+    leaf_index: UInt32,
+) -> Bytes[HYPERTREE_SIGNATURE_SIZE]:
   ADRS = bytearray(22)
 
   sig = b""
@@ -1759,7 +1798,14 @@ it against `sl_root`.
 This function is only used in the stateless path, and only by the verifier.
 
 ```py
-def hypertree_verify(message: bytes, signature: bytes, pk_seed: bytes, tree_index: int, leaf_index: int, sl_root: bytes) -> bool:
+def hypertree_verify(
+    message: Bytes[16],
+    signature: Bytes[HYPERTREE_SIGNATURE_SIZE],
+    pk_seed: Bytes[16],
+    tree_index: UInt64,
+    leaf_index: UInt32,
+    sl_root: Bytes[16],
+) -> bool:
   ADRS = bytearray(22)
 
   for j in range(SPHX_LAYER_COUNT):
@@ -1917,7 +1963,14 @@ The FXMSS internal node computation function. Recursively computes the FXMSS nod
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, sf_structure: bytes, ADRS: bytearray) -> bytes:
+def fxmss_node(
+    sk_seed: Bytes[16],
+    node_index: UInt64,
+    node_height: UInt8,
+    pk_seed: Bytes[16],
+    sf_structure: Bytes[2],
+    ADRS: bytearray,
+) -> Bytes[16]:
   node_depth = FXMSS_HEIGHT - node_height
   tree_shape, tree_depth = sf_structure[0], sf_structure[1]
 
@@ -1971,7 +2024,14 @@ The FXMSS signing function. Produces a deterministic WOTS+C signature at the lea
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_height: int, pk_seed: bytes, sf_structure: bytes) -> Optional[bytes]:
+def fxmss_sign(
+    message_digest: Bytes[32],
+    sk_seed: Bytes[16],
+    leaf_index: UInt64,
+    leaf_height: UInt8,
+    pk_seed: Bytes[16],
+    sf_structure: Bytes[2],
+) -> Optional[Bytes[FXMSS_SIGNATURE_SIZE_MIN:FXMSS_SIGNATURE_SIZE_MAX]]:
   leaf_depth = FXMSS_HEIGHT - leaf_height
 
   # Validate the leaf is positioned correctly for the specified tree structure.
@@ -2023,7 +2083,13 @@ WOTS+C leaf in the tree.
 This function is only used in the stateful path, and only by the verifier.
 
 ```py
-def fxmss_pubkey_from_sig(leaf_index: int, leaf_height: int, signature: bytes, message_digest: bytes, pk_seed: bytes) -> Optional[bytes]:
+def fxmss_pubkey_from_sig(
+    leaf_index: UInt64,
+    leaf_height: UInt8,
+    signature: Bytes[FXMSS_SIGNATURE_SIZE_MIN:FXMSS_SIGNATURE_SIZE_MAX],
+    message_digest: Bytes[32],
+    pk_seed: Bytes[16],
+) -> Optional[Bytes[16]]:
   wots_sig = signature[0 : 2+WOTS_C_CHAINS_SIZE]
   xmss_auth = signature[2+WOTS_C_CHAINS_SIZE : len(signature)]
   leaf_depth = FXMSS_HEIGHT - leaf_height
@@ -2120,7 +2186,9 @@ Note the `node_index` of a FORS leaf or node is _indexed across the entire fores
 within a single tree. The index of leaf `l` in tree `t` is `t * 2**SPHX_FORS_HEIGHT + l`.
 
 ```py
-def fors_sk_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray, node_index: int) -> bytes:
+def fors_sk_gen(
+    sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray, node_index: UInt32
+) -> Bytes[16]:
   ADRS[9] = SL_FORS_PRF
   ADRS[14:18] = zeros(4)
   ADRS[18:22] = node_index.to_bytes(4)
@@ -2153,7 +2221,9 @@ within a single tree. The index of node `l` in tree `t` at height `h` is
 `t * 2**(SPHX_FORS_HEIGHT - h) + l`.
 
 ```py
-def fors_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def fors_node(
+    sk_seed: Bytes[16], node_index: UInt32, node_height: UInt32, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   if node_height == 0:
     preimage = fors_sk_gen(sk_seed, pk_seed, ADRS, node_index)
     ADRS[9] = SL_FORS_TREE
@@ -2191,7 +2261,9 @@ prefilled with the location of the FORS keypair to ensure the hashes are properl
 This function is only used in the stateless path, and only by the signer.
 
 ```py
-def fors_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def fors_sign(
+    message_digest: Bytes[FORS_DIGEST_SIZE], sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[FORS_SIGNATURE_SIZE]:
   sig = b""
   index_set = base_2b(message_digest, SPHX_FORS_HEIGHT, SPHX_FORS_COUNT)
   for i in range(SPHX_FORS_COUNT):
@@ -2223,7 +2295,12 @@ the hashes are properly tweaked.
 This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
-def fors_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def fors_pubkey_from_sig(
+    signature: Bytes[FORS_SIGNATURE_SIZE],
+    message_digest: Bytes[FORS_DIGEST_SIZE],
+    pk_seed: Bytes[16],
+    ADRS: bytearray,
+) -> Bytes[16]:
   index_set = base_2b(message_digest, SPHX_FORS_HEIGHT, SPHX_FORS_COUNT)
 
   offset = 0
@@ -2294,13 +2371,17 @@ index, and FORS leaf index from `message` under `H_msg_sl`.
   - `message`: a variable-length message.
 - Outputs:
   - a `FORS_DIGEST_SIZE`-byte message digest, ready for use by FORS.
-  - a pseudorandomly selected index of a bottom-layer XMSS tree: an unsigned integer in `[0, 2**SPHX_TREE_INDEX_BITS)`.
-  - a pseudorandomly selected index of a FORS key within an XMSS tree: an unsigned integer in `[0, 2**SPHX_XMSS_HEIGHT)`.
+  - a 64-bit unsigned integer, a pseudorandomly selected index of a bottom-layer XMSS tree,
+    in `[0, 2**SPHX_TREE_INDEX_BITS)`.
+  - a 32-bit unsigned integer, a pseudorandomly selected index of a FORS key within an XMSS
+    tree, in `[0, 2**SPHX_XMSS_HEIGHT)`.
 
 This function is only used in the stateless path, and by both the signer and the verifier.
 
 ```py
-def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: bytes) -> tuple[bytes, int, int]:
+def slh_dsa_digest_message(
+    R: Bytes[16], pk_seed: Bytes[16], sl_root: Bytes[16], message: bytes
+) -> tuple[Bytes[FORS_DIGEST_SIZE], UInt64, UInt32]:
   digest = H_msg_sl(R, pk_seed, sl_root, message)
 
   fors_digest = digest[:FORS_DIGEST_SIZE]
@@ -2345,7 +2426,15 @@ hypertree signature, all concatenated together.
 This function is only used in the stateless path, and only by the signer.
 
 ```py
-def slh_dsa_sign(message: bytes, ctx: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed: bytes, sl_root: bytes, opt_rand: Optional[bytes]) -> bytes:
+def slh_dsa_sign(
+    message: bytes,
+    ctx: Bytes[:255],
+    sk_seed: Bytes[16],
+    sk_prf: Bytes[16],
+    pk_seed: Bytes[16],
+    sl_root: Bytes[16],
+    opt_rand: Optional[Bytes[16]],
+) -> Bytes[SPHX_SIGNATURE_SIZE]:
   assert len(ctx) < 256
   contextualized_msg = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + message
 
@@ -2377,7 +2466,8 @@ The SLH-DSA verification function. Recovers the root-tree root from a `signature
 
 - Inputs:
   - `message`: a variable-length message.
-  - `signature`: a `SPHX_SIGNATURE_SIZE`-byte signature.
+  - `signature`: a candidate signature, of any length. Any length other than
+    `SPHX_SIGNATURE_SIZE` is not a signature, and is rejected.
   - `ctx`: a context of at most 255 bytes.
   - `pk_seed`: a 16-byte salt.
   - `sl_root`: the 16-byte root hash of the stateless root tree.
@@ -2387,7 +2477,13 @@ The SLH-DSA verification function. Recovers the root-tree root from a `signature
 This function is only used in the stateless path, and only by the verifier.
 
 ```py
-def slh_dsa_verify(message: bytes, signature: bytes, ctx: bytes, pk_seed: bytes, sl_root: bytes) -> bool:
+def slh_dsa_verify(
+    message: bytes,
+    signature: bytes,
+    ctx: Bytes[:255],
+    pk_seed: Bytes[16],
+    sl_root: Bytes[16],
+) -> bool:
   assert len(ctx) < 256
   contextualized_msg = (0).to_bytes(1) + len(ctx).to_bytes(1) + ctx + message
 
@@ -2512,7 +2608,7 @@ This function is used only during key generation.
 > consuming compute resources by making the implementation generate a very large BXMSS tree.
 
 ```py
-def shrincs_keygen(seed: bytes, sf_structure: bytes) -> tuple[bytes, bytes]:
+def shrincs_keygen(seed: Bytes[48], sf_structure: Bytes[2]) -> tuple[Bytes[82], Bytes[48]]:
   assert len(seed) == 48
   assert len(sf_structure) == 2
 
@@ -2553,7 +2649,9 @@ key signs only on the stateless path.
 This function is only used in the stateful path, and only by the signer.
 
 ```py
-def shrincs_sf_leaf_select(sf_structure: bytes, state_ctr: Optional[int]) -> Optional[tuple[int, int]]:
+def shrincs_sf_leaf_select(
+    sf_structure: Bytes[2], state_ctr: Optional[UInt64]
+) -> Optional[tuple[UInt64, UInt8]]:
   if state_ctr is None:
     return None
 
@@ -2609,7 +2707,14 @@ This function is used only by the signer.
 > non-recoverable storage medium before the signature is returned to the caller.
 
 ```py
-def shrincs_sign(message: bytes, ctx: bytes, shrincs_seckey: bytes, state_ctr: Optional[int], opt_rand: Optional[bytes]) -> Optional[bytes]:
+def shrincs_sign(
+    message: Bytes[:2**61 - 384],
+    ctx: Bytes[:255],
+    shrincs_seckey: Bytes[82],
+    state_ctr: Optional[UInt64],
+    opt_rand: Optional[Bytes[16]],
+) -> Optional[Union[Bytes[SPHX_SIGNATURE_SIZE],
+                    Bytes[SHRINCS_SF_SIGNATURE_SIZE_MIN:SHRINCS_SF_SIGNATURE_SIZE_MAX]]]:
   sk_seed      = shrincs_seckey[0:16]
   sk_prf       = shrincs_seckey[16:32]
   pk_seed      = shrincs_seckey[32:48]
@@ -2674,7 +2779,10 @@ in memory-constrained environments.
 
 - Inputs:
   - `message`: a message of at most `2**61 - 384` bytes.
-  - `signature`: a candidate SHRINCS signature, of any length.
+  - `signature`: a candidate signature, of any length. The accepted lengths are exactly
+    `SPHX_SIGNATURE_SIZE` for the stateless path and `SHRINCS_SF_SIGNATURE_SIZE_MIN` to
+    `SHRINCS_SF_SIGNATURE_SIZE_MAX` in steps of 16 for the stateful path; any other
+    length is rejected.
   - `ctx`: a context of at most 255 bytes.
   - `shrincs_pubkey`: a 48-byte SHRINCS public key.
 - Output:
@@ -2683,7 +2791,9 @@ in memory-constrained environments.
 This function is used only by the verifier.
 
 ```py
-def shrincs_verify(message: bytes, signature: bytes, ctx: bytes, shrincs_pubkey: bytes) -> bool:
+def shrincs_verify(
+    message: Bytes[:2**61 - 384], signature: bytes, ctx: Bytes[:255], shrincs_pubkey: Bytes[48]
+) -> bool:
   pk_seed = shrincs_pubkey[0:16]
   sl_root = shrincs_pubkey[16:32]
   sf_root = shrincs_pubkey[32:48]

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -471,6 +471,14 @@ Every algorithm and every derived constant in this specification is computed wit
 Division in them appears only in the two integer forms above, so the specification never leaves a rounding decision to the implementation.
 Note that `ceildiv(a, b)` must round up for every `a` it is given: writing it as a division that rounds toward zero, which is what the division operator does in most languages, would silently round down instead.
 
+Every quantity in this specification denotes a mathematical integer, and every operation on one is exact.
+Nothing overflows, underflows, wraps, is reduced modulo a word size, saturates, or is truncated; a difference is never clamped at zero, and the only rounding is that of the two division forms above.
+An operation whose result would fall outside the range this specification gives that value does not yield some other value instead: it violates the specification.
+
+The [value types](#value-types) above are therefore refinements, not representations.
+`UInt8` through `UInt64` assert that a value lies in `[0, 2**8)` through `[0, 2**64)`.
+They do not make it a machine word, and no arithmetic is ever performed modulo `2**bits`.
+
 Unless stated otherwise, all integers are serialized to and parsed from bytes as fixed-width, big-endian (network byte order) values, where the width is the size of the byte field the integer occupies.
 
 

--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -460,7 +460,10 @@ Writing one into a narrower field is an error rather than a value reduced to fit
 We make use of the following utility helper functions in specifying SHRINCS.
 
 - `a // b`: divides the integer `a` by the integer `b`, rounding the quotient down.
+- `a % b`: the remainder `a - b * (a // b)`. In every use below `a` is non-negative and `b` is positive, so the result lies in `[0, b)`.
 - `ceildiv(a, b)`: divides the integer `a` by the integer `b`, rounding the quotient up.
+- `a ** b`: raises the integer `a` to the power of the non-negative integer `b`.
+- `xor(s1, s2)`: the bytewise exclusive or of two byte strings of equal length.
 - `sum(x)`: sums a sequence of numbers `x`.
 - `replicate(b, n)`: returns a bytestring of length `n` containing only the repeated byte `b`.
 - `zeros(n)`: returns a bytestring of  length `n` containing only repeated zero bytes.
@@ -468,16 +471,17 @@ We make use of the following utility helper functions in specifying SHRINCS.
 - `concat(array)`: concatenates an array of byte strings.
 
 Every algorithm and every derived constant in this specification is computed with exact integer arithmetic.
-Division in them appears only in the two integer forms above, so the specification never leaves a rounding decision to the implementation.
+Division in them appears only as `a // b`, `a % b` and `ceildiv(a, b)`, and in every use the operands are non-negative, so floored and truncated division agree and the specification never leaves a rounding decision to the implementation.
 Note that `ceildiv(a, b)` must round up for every `a` it is given: writing it as a division that rounds toward zero, which is what the division operator does in most languages, would silently round down instead.
 
 Every quantity in this specification denotes a mathematical integer, and every operation on one is exact.
-Nothing overflows, underflows, wraps, is reduced modulo a word size, saturates, or is truncated; a difference is never clamped at zero, and the only rounding is that of the two division forms above.
+Nothing overflows, underflows, wraps, is reduced modulo a word size, saturates, or is truncated; a difference is never clamped at zero, and the only rounding is that of `a // b` and `ceildiv(a, b)`.
 An operation whose result would fall outside the range this specification gives that value does not yield some other value instead: it violates the specification.
 
 The [value types](#value-types) above are therefore refinements, not representations.
 `UInt8` through `UInt64` assert that a value lies in `[0, 2**8)` through `[0, 2**64)`.
 They do not make it a machine word, and no arithmetic is ever performed modulo `2**bits`.
+No quantity is ever shifted or masked in place of arithmetic.
 
 Unless stated otherwise, all integers are serialized to and parsed from bytes as fixed-width, big-endian (network byte order) values, where the width is the size of the byte field the integer occupies.
 
@@ -500,12 +504,12 @@ def base_2b(x: bytes, b: int, outlen: int) -> list[int]:
 
   for i in range(outlen):
     while bits_filled < b:
-      acc = (acc << 8) + x[j]
+      acc = acc * 256 + x[j]
       j += 1
       bits_filled += 8
 
     bits_filled -= b
-    baseb[i] = acc >> bits_filled
+    baseb[i] = acc // 2**bits_filled
     acc %= 2**bits_filled # prevent accumulator from overflowing
 
   return baseb
@@ -1176,7 +1180,7 @@ def wots_tw_message_to_indexes(message: Bytes[16]) -> Array[UInt16, WOTS_TW_CHAI
   checksum_indexes = [0] * WOTS_TW_CHAIN_COUNT2
   for i in range(WOTS_TW_CHAIN_COUNT2):
     checksum_indexes[WOTS_TW_CHAIN_COUNT2 - 1 - i] = checksum % (2**WOTS_TW_CHAIN_BITS)
-    checksum >>= WOTS_TW_CHAIN_BITS
+    checksum = checksum // 2**WOTS_TW_CHAIN_BITS
 
   return msg_indexes + checksum_indexes
 ```
@@ -1191,7 +1195,7 @@ def wots_tw_message_to_indexes_alt(message: Bytes[16]) -> Array[UInt16, WOTS_TW_
   SPHX_WOTS_CHECKSUM_SHIFT = (8 - (WOTS_TW_CHAIN_BITS * WOTS_TW_CHAIN_COUNT2) % 8) % 8
   SPHX_WOTS_CHECKSUM_BYTE_LEN = ceildiv(WOTS_TW_CHAIN_COUNT2 * WOTS_TW_CHAIN_BITS, 8)
   msg_indexes = base_2b(message, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT1)
-  checksum = (WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)) << SPHX_WOTS_CHECKSUM_SHIFT
+  checksum = (WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)) * 2**SPHX_WOTS_CHECKSUM_SHIFT
   checksum_bytes = checksum.to_bytes(SPHX_WOTS_CHECKSUM_BYTE_LEN)
   checksum_indexes = base_2b(checksum_bytes, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT2)
   return msg_indexes + checksum_indexes
@@ -1200,7 +1204,7 @@ def wots_tw_message_to_indexes_alt(message: Bytes[16]) -> Array[UInt16, WOTS_TW_
 
 This algorithm is used by both signer and verifier, and **it is security-critical for both implementations to match.**
 
-Note especially how the _low-order_ bits of the checksum are shifted off first, and they are inserted snugly at the very end of the checksum indexes, with some padding bits which are always zero in between them and the message indexes.
+Note especially how the _low-order_ bits of the checksum are divided out first, and they are inserted snugly at the very end of the checksum indexes, with some padding bits which are always zero in between them and the message indexes.
 The checksum bits are NOT appended directly to the message indexes.
 
 
@@ -1817,7 +1821,7 @@ def hypertree_sign(
     if j < SPHX_LAYER_COUNT - 1:
       message = xmss_pubkey_from_sig(leaf_index, layer_sig, message, pk_seed, ADRS)
       leaf_index = tree_index % (2**SPHX_XMSS_HEIGHT)
-      tree_index >>= SPHX_XMSS_HEIGHT
+      tree_index = tree_index // 2**SPHX_XMSS_HEIGHT
     sig += layer_sig
 
   return sig
@@ -1861,7 +1865,7 @@ def hypertree_verify(
     message = xmss_pubkey_from_sig(leaf_index, layer_sig, message, pk_seed, ADRS)
     if j < SPHX_LAYER_COUNT - 1:
       leaf_index = tree_index % (2**SPHX_XMSS_HEIGHT)
-      tree_index >>= SPHX_XMSS_HEIGHT
+      tree_index = tree_index // 2**SPHX_XMSS_HEIGHT
   return message == sl_root
 ```
 <!-- DOC END hypertree_verify -->

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -160,6 +160,36 @@ UInt32 = Annotated[int, UINT(32)]
 UInt64 = Annotated[int, UINT(64)]
 
 
+#  Node index helpers
+
+def sibling_of(node_index: int) -> int:
+  """
+  Returns the index of the other child of the same parent: the next index up
+  from an even node, the previous from an odd one. An odd index is at least
+  one, so the difference is never taken below zero, and an even index is below
+  the top of its range, so the sum stays in it.
+  """
+  if node_index % 2 == 0:
+    return node_index + 1
+  else:
+    return node_index - 1
+
+
+def ancestor_of(node_index: int, levels: int) -> int:
+  """
+  Returns the index of the node `levels` above the node at `node_index`.
+  Each layer is half as wide as the one below it, so climbing a level halves the
+  index, and an index halved past zero stays there. The result is
+  `node_index // 2**levels`, but not computed that way: `levels` reaches
+  `FXMSS_HEIGHT`, past the width of the index it climbs, where languages differ
+  on what a shift that far means.
+  """
+  for _ in range(levels):
+    node_index = node_index // 2
+
+  return node_index
+
+
 #  Primitive cryptographic functions
 
 def sha256(message: Bytes[:2**61 - 1]) -> Bytes[32]:
@@ -776,7 +806,7 @@ def xmss_sign(
 
   # Append the Merkle authentication path.
   for j in range(SPHX_XMSS_HEIGHT):
-    sibling_index = (keypair_index >> j) ^ 1
+    sibling_index = sibling_of(ancestor_of(keypair_index, j))
     sig += xmss_node(sk_seed, sibling_index, j, pk_seed, ADRS)
 
   return sig
@@ -815,9 +845,9 @@ def xmss_pubkey_from_sig(
 
   for k in range(SPHX_XMSS_HEIGHT):
     ADRS[14:18] = (k + 1).to_bytes(4)
-    ADRS[18:22] = (keypair_index >> (k+1)).to_bytes(4)
+    ADRS[18:22] = ancestor_of(keypair_index, k + 1).to_bytes(4)
     sibling = xmss_auth[k*16 : (k+1)*16]
-    if (keypair_index >> k) & 1 == 1:
+    if ancestor_of(keypair_index, k) % 2 == 1:
       node = H(pk_seed, ADRS, sibling + node)
     else:
       node = H(pk_seed, ADRS, node + sibling)
@@ -1013,7 +1043,7 @@ def fxmss_sign(
 
   # Append the Merkle authentication path.
   for j in range(leaf_depth):
-    sibling_index = (leaf_index >> j) ^ 1
+    sibling_index = sibling_of(ancestor_of(leaf_index, j))
     sibling_height = leaf_height + j
     sig += fxmss_node(sk_seed, sibling_index, sibling_height, pk_seed, tree_balanced, tree_depth, ADRS)
 
@@ -1065,9 +1095,9 @@ def fxmss_pubkey_from_sig(
 
   for k in range(leaf_depth):
     ADRS[0] += 1
-    ADRS[1:9] = (leaf_index >> (k+1)).to_bytes(8)
+    ADRS[1:9] = ancestor_of(leaf_index, k + 1).to_bytes(8)
     sibling = xmss_auth[k*16 : (k+1)*16]
-    if (leaf_index >> k) & 1 == 1:
+    if ancestor_of(leaf_index, k) % 2 == 1:
       node = H(pk_seed, ADRS, sibling + node)
     else:
       node = H(pk_seed, ADRS, node + sibling)
@@ -1167,7 +1197,7 @@ def fors_sign(
     leaf_index = i * 2**SPHX_FORS_HEIGHT + index_set[i]
     sig += fors_sk_gen(sk_seed, pk_seed, ADRS, leaf_index)
     for j in range(SPHX_FORS_HEIGHT):
-      sibling_index = i * 2**(SPHX_FORS_HEIGHT - j) + ((index_set[i] >> j) ^ 1)
+      sibling_index = i * 2**(SPHX_FORS_HEIGHT - j) + sibling_of(ancestor_of(index_set[i], j))
       sig += fors_node(sk_seed, sibling_index, j, pk_seed, ADRS)
   return sig
 
@@ -1207,12 +1237,12 @@ def fors_pubkey_from_sig(
     node = F(pk_seed, ADRS, preimage)
     for j in range(SPHX_FORS_HEIGHT):
       ADRS[14:18] = (j + 1).to_bytes(4)
-      ADRS[18:22] = (tree_index >> (j+1)).to_bytes(4)
+      ADRS[18:22] = ancestor_of(tree_index, j + 1).to_bytes(4)
 
       sibling = signature[offset : offset+16]
       offset += 16
 
-      if (index_set[i] >> j) & 1 == 1:
+      if ancestor_of(index_set[i], j) % 2 == 1:
         node = H(pk_seed, ADRS, sibling + node)
       else:
         node = H(pk_seed, ADRS, node + sibling)

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -114,6 +114,10 @@ SF_WOTS_C_GRIND = 22
 
 
 #  Value types
+#
+#  Every quantity here is a mathematical integer and every operation on one is
+#  exact: nothing wraps, saturates, or is truncated. The annotations state where
+#  a value lies, not how it is stored.
 
 class LEN:
   """

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -50,12 +50,12 @@ def base_2b(x: bytes, b: int, outlen: int) -> list[int]:
 
   for i in range(outlen):
     while bits_filled < b:
-      acc = (acc << 8) + x[j]
+      acc = acc * 256 + x[j]
       j += 1
       bits_filled += 8
 
     bits_filled -= b
-    baseb[i] = acc >> bits_filled
+    baseb[i] = acc // 2**bits_filled
     acc %= 2**bits_filled # prevent accumulator from overflowing
 
   return baseb
@@ -117,7 +117,8 @@ SF_WOTS_C_GRIND = 22
 #
 #  Every quantity here is a mathematical integer and every operation on one is
 #  exact: nothing wraps, saturates, or is truncated. The annotations state where
-#  a value lies, not how it is stored.
+#  a value lies, not how it is stored. Nothing here is shifted or masked in
+#  place of arithmetic.
 
 class LEN:
   """
@@ -486,7 +487,7 @@ def wots_tw_message_to_indexes(message: Bytes[16]) -> Array[UInt16, WOTS_TW_CHAI
   checksum_indexes = [0] * WOTS_TW_CHAIN_COUNT2
   for i in range(WOTS_TW_CHAIN_COUNT2):
     checksum_indexes[WOTS_TW_CHAIN_COUNT2 - 1 - i] = checksum % (2**WOTS_TW_CHAIN_BITS)
-    checksum >>= WOTS_TW_CHAIN_BITS
+    checksum = checksum // 2**WOTS_TW_CHAIN_BITS
 
   return msg_indexes + checksum_indexes
 
@@ -498,7 +499,7 @@ def wots_tw_message_to_indexes_alt(message: Bytes[16]) -> Array[UInt16, WOTS_TW_
   SPHX_WOTS_CHECKSUM_SHIFT = (8 - (WOTS_TW_CHAIN_BITS * WOTS_TW_CHAIN_COUNT2) % 8) % 8
   SPHX_WOTS_CHECKSUM_BYTE_LEN = ceildiv(WOTS_TW_CHAIN_COUNT2 * WOTS_TW_CHAIN_BITS, 8)
   msg_indexes = base_2b(message, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT1)
-  checksum = (WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)) << SPHX_WOTS_CHECKSUM_SHIFT
+  checksum = (WOTS_TW_CHECKSUM_MAX - sum(msg_indexes)) * 2**SPHX_WOTS_CHECKSUM_SHIFT
   checksum_bytes = checksum.to_bytes(SPHX_WOTS_CHECKSUM_BYTE_LEN)
   checksum_indexes = base_2b(checksum_bytes, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT2)
   return msg_indexes + checksum_indexes
@@ -888,7 +889,7 @@ def hypertree_sign(
     if j < SPHX_LAYER_COUNT - 1:
       message = xmss_pubkey_from_sig(leaf_index, layer_sig, message, pk_seed, ADRS)
       leaf_index = tree_index % (2**SPHX_XMSS_HEIGHT)
-      tree_index >>= SPHX_XMSS_HEIGHT
+      tree_index = tree_index // 2**SPHX_XMSS_HEIGHT
     sig += layer_sig
 
   return sig
@@ -926,7 +927,7 @@ def hypertree_verify(
     message = xmss_pubkey_from_sig(leaf_index, layer_sig, message, pk_seed, ADRS)
     if j < SPHX_LAYER_COUNT - 1:
       leaf_index = tree_index % (2**SPHX_XMSS_HEIGHT)
-      tree_index >>= SPHX_XMSS_HEIGHT
+      tree_index = tree_index // 2**SPHX_XMSS_HEIGHT
   return message == sl_root
 
 

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -158,7 +158,7 @@ UInt64 = Annotated[int, UINT(64)]
 
 #  Primitive cryptographic functions
 
-def sha256(message: bytes) -> bytes:
+def sha256(message: Bytes[:2**61 - 1]) -> Bytes[32]:
   """
   The `sha256` hash function.
 
@@ -169,7 +169,7 @@ def sha256(message: bytes) -> bytes:
   """
   return hashlib.sha256(bytes(message)).digest()
 
-def hmac_sha256(key: bytes, message: bytes) -> bytes:
+def hmac_sha256(key: Bytes[:64], message: Bytes[:2**61 - 1 - 64]) -> Bytes[32]:
   """
   The `hmac_sha256` keyed hash function.
 
@@ -187,7 +187,7 @@ def hmac_sha256(key: bytes, message: bytes) -> bytes:
 
 # Tweaked hash functions
 
-def T_sl(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
+def T_sl(pk_seed: Bytes[16], ADRS: bytearray, M_l: Bytes[WOTS_TW_CHAINS_SIZE]) -> Bytes[16]:
   """
   The `T_sl` tweaked hash function. Compresses `WOTS_TW_CHAIN_COUNT` Winternitz chain tips into a
   single 16-byte hash.
@@ -203,7 +203,7 @@ def T_sl(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
   """
   return sha256(pk_seed + zeros(48) + ADRS + M_l)[:16]
 
-def T_sf(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
+def T_sf(pk_seed: Bytes[16], ADRS: bytearray, M_l: Bytes[WOTS_C_CHAINS_SIZE]) -> Bytes[16]:
   """
   The `T_sf` tweaked hash function. Compresses `WOTS_C_CHAIN_COUNT` Winternitz chain tips into a
   single 16-byte hash.
@@ -219,7 +219,7 @@ def T_sf(pk_seed: bytes, ADRS: bytearray, M_l: bytes) -> bytes:
   """
   return sha256(pk_seed + zeros(48) + ADRS + M_l)[:16]
 
-def T_k(pk_seed: bytes, ADRS: bytearray, M_k: bytes) -> bytes:
+def T_k(pk_seed: Bytes[16], ADRS: bytearray, M_k: Bytes[SPHX_FORS_COUNT * 16]) -> Bytes[16]:
   """
   The `T_k` tweaked hash function. Compresses `SPHX_FORS_COUNT` FORS tree roots into a single
   16-byte hash.
@@ -235,7 +235,7 @@ def T_k(pk_seed: bytes, ADRS: bytearray, M_k: bytes) -> bytes:
   """
   return sha256(pk_seed + zeros(48) + ADRS + M_k)[:16]
 
-def F(pk_seed: bytes, ADRS: bytearray, M_1: bytes) -> bytes:
+def F(pk_seed: Bytes[16], ADRS: bytearray, M_1: Bytes[16]) -> Bytes[16]:
   """
   The `F` tweaked hash function. Hashes a single 16-byte input, to generate and iterate Winternitz
   hash chains and to hash FORS leaves.
@@ -251,7 +251,7 @@ def F(pk_seed: bytes, ADRS: bytearray, M_1: bytes) -> bytes:
   """
   return sha256(pk_seed + zeros(48) + ADRS + M_1)[:16]
 
-def H(pk_seed: bytes, ADRS: bytearray, M_2: bytes) -> bytes:
+def H(pk_seed: Bytes[16], ADRS: bytearray, M_2: Bytes[32]) -> Bytes[16]:
   """
   The `H` tweaked hash function. Combines a pair of 16-byte Merkle child nodes into their 16-byte
   parent, building the Merkle trees in XMSS and FORS.
@@ -267,7 +267,7 @@ def H(pk_seed: bytes, ADRS: bytearray, M_2: bytes) -> bytes:
   """
   return sha256(pk_seed + zeros(48) + ADRS + M_2)[:16]
 
-def H_grind(pk_seed: bytes, ADRS: bytearray, digest: bytes, counter: int) -> bytes:
+def H_grind(pk_seed: Bytes[16], ADRS: bytearray, digest: Bytes[32], counter: UInt16) -> Bytes[16]:
   """
   The `H_grind` tweaked hash function. Maps a 32-byte `digest` and grinding `counter` into the
   constant-sum message space for WOTS+C.
@@ -285,7 +285,7 @@ def H_grind(pk_seed: bytes, ADRS: bytearray, digest: bytes, counter: int) -> byt
   assert counter <= 0xFFFF
   return sha256(pk_seed + zeros(48) + ADRS[:10] + digest + zeros(4) + counter.to_bytes(2))[:16]
 
-def PRF(pk_seed: bytes, sk_seed: bytes, ADRS: bytearray) -> bytes:
+def PRF(pk_seed: Bytes[16], sk_seed: Bytes[16], ADRS: bytearray) -> Bytes[16]:
   """
   The `PRF` pseudorandom function. Derives a secret 16-byte preimage from `sk_seed`, for signing
   and key generation.
@@ -301,7 +301,7 @@ def PRF(pk_seed: bytes, sk_seed: bytes, ADRS: bytearray) -> bytes:
   """
   return sha256(pk_seed + zeros(48) + ADRS + sk_seed)[:16]
 
-def H_msg_sl(R: bytes, pk_seed: bytes, sl_root: bytes, M: bytes) -> bytes:
+def H_msg_sl(R: Bytes[16], pk_seed: Bytes[16], sl_root: Bytes[16], M: bytes) -> Bytes[32]:
   """
   The `H_msg_sl` message hash function. Produces the 32-byte signing digest for the stateless path.
 
@@ -319,7 +319,9 @@ def H_msg_sl(R: bytes, pk_seed: bytes, sl_root: bytes, M: bytes) -> bytes:
   """
   return sha256(R + pk_seed + sha256(R + pk_seed + sl_root + M) + zeros(4))
 
-def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes) -> bytes:
+def H_msg_sf(
+    R: Bytes[16], pk_seed: Bytes[16], sf_root: Bytes[16], ADRS: bytearray, M: bytes
+) -> Bytes[32]:
   """
   The `H_msg_sf` message hash function. Produces the 32-byte signing digest for the stateful path.
 
@@ -338,7 +340,7 @@ def H_msg_sf(R: bytes, pk_seed: bytes, sf_root: bytes, ADRS: bytearray, M: bytes
   """
   return sha256(R + pk_seed + sha256(R + pk_seed + sf_root + ADRS[:9] + M) + ADRS[:9])
 
-def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
+def PRF_msg_sl(sk_prf: Bytes[16], opt_rand: Bytes[16], M: bytes) -> Bytes[16]:
   """
   The `PRF_msg_sl` pseudorandom function. Derives the per-message randomizer (salt) for the stateless path via
   HMAC-SHA256.
@@ -358,7 +360,7 @@ def PRF_msg_sl(sk_prf: bytes, opt_rand: bytes, M: bytes) -> bytes:
   """
   return hmac_sha256(key=sk_prf, message=opt_rand + M)[:16]
 
-def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> bytes:
+def PRF_msg_sf(sk_prf: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray, M: bytes) -> Bytes[16]:
   """
   The `PRF_msg_sf` function. Derives the per-message randomizer (salt) for the stateful path via
   HMAC-SHA256.
@@ -378,7 +380,9 @@ def PRF_msg_sf(sk_prf: bytes, pk_seed: bytes, ADRS: bytearray, M: bytes) -> byte
 
 #  Winternitz algorithms
 
-def wots_tw_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_chain_iter(
+    node: Bytes[16], start: UInt8, steps: UInt8, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   """
   The WOTS-TW hash chain iteration function. Iterates the hash chain from index `start` by `steps`
   steps, returning the node at index `start + steps`. The `ADRS` must be prefilled with the keypair
@@ -386,9 +390,10 @@ def wots_tw_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS
 
   - Inputs:
     - `node`: a 16-byte hash.
-    - `start`: a 32-bit unsigned integer, the index of `node` in its hash chain.
-    - `steps`: a 32-bit unsigned integer, the number of steps to take up the chain; `start + steps` must
-      not exceed `2**WOTS_TW_CHAIN_BITS - 1`.
+    - `start`: an 8-bit unsigned integer, the index of `node` in its hash chain, less than
+      `2**WOTS_TW_CHAIN_BITS`.
+    - `steps`: an 8-bit unsigned integer, the number of steps to take up the chain; `start + steps`
+      must not exceed `2**WOTS_TW_CHAIN_BITS - 1`.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
@@ -402,7 +407,9 @@ def wots_tw_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS
     node = F(pk_seed, ADRS, node)
   return node
 
-def wots_c_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_c_chain_iter(
+    node: Bytes[16], start: UInt8, steps: UInt8, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   """
   The WOTS+C hash chain iteration function. Iterates the hash chain from index `start` by `steps`
   steps, returning the node at index `start + steps`. The `ADRS` must be prefilled with the keypair
@@ -410,9 +417,10 @@ def wots_c_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS:
 
   - Inputs:
     - `node`: a 16-byte hash.
-    - `start`: a 32-bit unsigned integer, the index of `node` in its hash chain.
-    - `steps`: a 32-bit unsigned integer, the number of steps to take up the chain; `start + steps` must
-      not exceed `2**WOTS_C_CHAIN_BITS - 1`.
+    - `start`: an 8-bit unsigned integer, the index of `node` in its hash chain, less than
+      `2**WOTS_C_CHAIN_BITS`.
+    - `steps`: an 8-bit unsigned integer, the number of steps to take up the chain; `start + steps`
+      must not exceed `2**WOTS_C_CHAIN_BITS - 1`.
     - `pk_seed`: a 16-byte salt.
     - `ADRS`: a 22-byte address.
   - Output:
@@ -426,7 +434,7 @@ def wots_c_chain_iter(node: bytes, start: int, steps: int, pk_seed: bytes, ADRS:
     node = F(pk_seed, ADRS, node)
   return node
 
-def wots_tw_message_to_indexes(message: bytes) -> list[int]:
+def wots_tw_message_to_indexes(message: Bytes[16]) -> Array[UInt16, WOTS_TW_CHAIN_COUNT]:
   """
   The WOTS-TW message map function. Converts a 16-byte `message` into a checksummed array of
   `WOTS_TW_CHAIN_COUNT` chain indexes in `[0, 2**WOTS_TW_CHAIN_BITS)`.
@@ -448,7 +456,7 @@ def wots_tw_message_to_indexes(message: bytes) -> list[int]:
 
   return msg_indexes + checksum_indexes
 
-def wots_tw_message_to_indexes_alt(message: bytes) -> list[int]:
+def wots_tw_message_to_indexes_alt(message: Bytes[16]) -> Array[UInt16, WOTS_TW_CHAIN_COUNT]:
   """
   Alternative implementation, equivalent to `wots_tw_message_to_indexes` but using the
   more complex FIPS-205 algorithm.
@@ -461,7 +469,7 @@ def wots_tw_message_to_indexes_alt(message: bytes) -> list[int]:
   checksum_indexes = base_2b(checksum_bytes, WOTS_TW_CHAIN_BITS, WOTS_TW_CHAIN_COUNT2)
   return msg_indexes + checksum_indexes
 
-def wots_tw_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_pubkey_gen(sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray) -> Bytes[16]:
   """
   The WOTS-TW public key generation function. Computes the 16-byte WOTS-TW public key at the
   keypair location prefilled in `ADRS`.
@@ -488,7 +496,9 @@ def wots_tw_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes
   wots_pk_hash = T_sl(pk_seed, ADRS, concat(wots_pk))
   return wots_pk_hash
 
-def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_sign(
+    message: Bytes[16], sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[WOTS_TW_CHAINS_SIZE]:
   """
   The WOTS-TW signing function. Produces a WOTS-TW signature on a 16-byte `message`, at the keypair
   location prefilled in `ADRS`.
@@ -513,7 +523,9 @@ def wots_tw_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray
     signature[i] = wots_tw_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
   return concat(signature)
 
-def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_tw_pubkey_from_sig(
+    signature: Bytes[WOTS_TW_CHAINS_SIZE], message: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   """
   The WOTS-TW verification function. Recovers a WOTS-TW public key from a `signature` on a 16-byte
   `message`.
@@ -540,7 +552,9 @@ def wots_tw_pubkey_from_sig(signature: bytes, message: bytes, pk_seed: bytes, AD
   wots_pk_hash = T_sl(pk_seed, ADRS, concat(wots_pk))
   return wots_pk_hash
 
-def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: bytearray) -> Optional[tuple[int, list[int]]]:
+def wots_c_grind_to_constant_sum(
+    pk_seed: Bytes[16], message_digest: Bytes[32], ADRS: bytearray
+) -> Optional[tuple[UInt16, Array[UInt16, WOTS_C_CHAIN_COUNT]]]:
   """
   The WOTS+C grinding function. Grinds up to 2^16 counters until one maps `message_digest` to a
   constant-sum index set, returning the lowest such counter and its index set.
@@ -565,7 +579,9 @@ def wots_c_grind_to_constant_sum(pk_seed: bytes, message_digest: bytes, ADRS: by
 
   return None # practically impossible
 
-def wots_c_map_digest(pk_seed: bytes, message_digest: bytes, ADRS: bytearray, counter: int) -> Optional[list[int]]:
+def wots_c_map_digest(
+    pk_seed: Bytes[16], message_digest: Bytes[32], ADRS: bytearray, counter: UInt16
+) -> Optional[Array[UInt16, WOTS_C_CHAIN_COUNT]]:
   """
   The WOTS+C digest validation function. Evaluates a signature's grinding `counter` and returns the
   constant-sum index set it yields, or null if the counter is invalid.
@@ -588,7 +604,7 @@ def wots_c_map_digest(pk_seed: bytes, message_digest: bytes, ADRS: bytearray, co
   else:
     return None
 
-def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def wots_c_pubkey_gen(sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray) -> Bytes[16]:
   """
   The WOTS+C public key generation function. Computes the 16-byte WOTS+C public key at the keypair
   location prefilled in `ADRS`.
@@ -618,7 +634,9 @@ def wots_c_pubkey_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
   wots_pk_hash = T_sf(pk_seed, ADRS, concat(wots_pk))
   return wots_pk_hash
 
-def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> Optional[bytes]:
+def wots_c_sign(
+    message_digest: Bytes[32], sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray
+) -> Optional[Bytes[2 + WOTS_C_CHAINS_SIZE]]:
   """
   The WOTS+C signing function. Produces a WOTS+C signature on a 32-byte `message_digest`, at the
   keypair location prefilled in `ADRS`.
@@ -651,7 +669,12 @@ def wots_c_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: byt
     signature[i] = wots_c_chain_iter(sk, 0, indexes[i], pk_seed, ADRS)
   return counter.to_bytes(2) + concat(signature)
 
-def wots_c_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes, ADRS: bytearray) -> Optional[bytes]:
+def wots_c_pubkey_from_sig(
+    signature: Bytes[2 + WOTS_C_CHAINS_SIZE],
+    message_digest: Bytes[32],
+    pk_seed: Bytes[16],
+    ADRS: bytearray,
+) -> Optional[Bytes[16]]:
   """
   The WOTS+C verification function. Recovers a WOTS+C public key from a `signature` on a 32-byte
   `message_digest`.
@@ -688,7 +711,9 @@ def wots_c_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: byt
 
 #  XMSS algorithms
 
-def xmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def xmss_node(
+    sk_seed: Bytes[16], node_index: UInt32, node_height: UInt32, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   """
   The XMSS internal node computation function. Recursively computes the XMSS node at the given
   `node_index` and `node_height`. The `ADRS` must be prefilled with the location of the XMSS tree
@@ -722,7 +747,9 @@ def xmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes,
   ADRS[18:22] = node_index.to_bytes(4)
   return H(pk_seed, ADRS, lchild + rchild)
 
-def xmss_sign(message: bytes, sk_seed: bytes, keypair_index: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def xmss_sign(
+    message: Bytes[16], sk_seed: Bytes[16], keypair_index: UInt32, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[SPHX_XMSS_SIGNATURE_SIZE]:
   """
   The XMSS signing function. Produces a deterministic WOTS-TW signature at leaf `keypair_index` and
   appends the Merkle authentication path to form an XMSS signature. The `ADRS` must be prefilled with
@@ -750,7 +777,13 @@ def xmss_sign(message: bytes, sk_seed: bytes, keypair_index: int, pk_seed: bytes
 
   return sig
 
-def xmss_pubkey_from_sig(keypair_index: int, signature: bytes, message: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def xmss_pubkey_from_sig(
+    keypair_index: UInt32,
+    signature: Bytes[SPHX_XMSS_SIGNATURE_SIZE],
+    message: Bytes[16],
+    pk_seed: Bytes[16],
+    ADRS: bytearray,
+) -> Bytes[16]:
   """
   The XMSS verification function. Recovers an XMSS root from a `signature` on a 16-byte `message`
   at leaf `keypair_index`. The `ADRS` must be prefilled with the location of the XMSS tree in the
@@ -790,7 +823,13 @@ def xmss_pubkey_from_sig(keypair_index: int, signature: bytes, message: bytes, p
 
 #  Hypertree algorithms
 
-def hypertree_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, tree_index: int, leaf_index: int) -> bytes:
+def hypertree_sign(
+    message: Bytes[16],
+    sk_seed: Bytes[16],
+    pk_seed: Bytes[16],
+    tree_index: UInt64,
+    leaf_index: UInt32,
+) -> Bytes[HYPERTREE_SIGNATURE_SIZE]:
   """
   The hypertree signing function. Signs a 16-byte `message` through a hypertree of XMSS trees.
 
@@ -820,7 +859,14 @@ def hypertree_sign(message: bytes, sk_seed: bytes, pk_seed: bytes, tree_index: i
 
   return sig
 
-def hypertree_verify(message: bytes, signature: bytes, pk_seed: bytes, tree_index: int, leaf_index: int, sl_root: bytes) -> bool:
+def hypertree_verify(
+    message: Bytes[16],
+    signature: Bytes[HYPERTREE_SIGNATURE_SIZE],
+    pk_seed: Bytes[16],
+    tree_index: UInt64,
+    leaf_index: UInt32,
+    sl_root: Bytes[16],
+) -> bool:
   """
   The hypertree verification function. Recovers the hypertree root from a `signature` and compares
   it against `sl_root`.
@@ -852,7 +898,14 @@ def hypertree_verify(message: bytes, signature: bytes, pk_seed: bytes, tree_inde
 
 #  FXMSS algorithms
 
-def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, sf_structure: bytes, ADRS: bytearray) -> bytes:
+def fxmss_node(
+    sk_seed: Bytes[16],
+    node_index: UInt64,
+    node_height: UInt8,
+    pk_seed: Bytes[16],
+    sf_structure: Bytes[2],
+    ADRS: bytearray,
+) -> Bytes[16]:
   """
   The FXMSS internal node computation function. Recursively computes the FXMSS node at the given
   `node_index` and `node_height` for the tree `sf_structure`.
@@ -900,7 +953,14 @@ def fxmss_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes
   ADRS[10:22] = zeros(12)
   return H(pk_seed, ADRS, lchild + rchild)
 
-def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_height: int, pk_seed: bytes, sf_structure: bytes) -> Optional[bytes]:
+def fxmss_sign(
+    message_digest: Bytes[32],
+    sk_seed: Bytes[16],
+    leaf_index: UInt64,
+    leaf_height: UInt8,
+    pk_seed: Bytes[16],
+    sf_structure: Bytes[2],
+) -> Optional[Bytes[FXMSS_SIGNATURE_SIZE_MIN:FXMSS_SIGNATURE_SIZE_MAX]]:
   """
   The FXMSS signing function. Produces a deterministic WOTS+C signature at the leaf given by
   `leaf_index`/`leaf_height` and appends the Merkle authentication path to form an FXMSS signature.
@@ -942,7 +1002,13 @@ def fxmss_sign(message_digest: bytes, sk_seed: bytes, leaf_index: int, leaf_heig
 
   return sig
 
-def fxmss_pubkey_from_sig(leaf_index: int, leaf_height: int, signature: bytes, message_digest: bytes, pk_seed: bytes) -> Optional[bytes]:
+def fxmss_pubkey_from_sig(
+    leaf_index: UInt64,
+    leaf_height: UInt8,
+    signature: Bytes[FXMSS_SIGNATURE_SIZE_MIN:FXMSS_SIGNATURE_SIZE_MAX],
+    message_digest: Bytes[32],
+    pk_seed: Bytes[16],
+) -> Optional[Bytes[16]]:
   """
   The FXMSS verification function. Recovers an FXMSS root from a `signature` on a 32-byte
   `message_digest`. The `leaf_height` and `leaf_index` arguments give the position of the
@@ -994,7 +1060,9 @@ def fxmss_pubkey_from_sig(leaf_index: int, leaf_height: int, signature: bytes, m
 
 #  FORS algorithms
 
-def fors_sk_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray, node_index: int) -> bytes:
+def fors_sk_gen(
+    sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray, node_index: UInt32
+) -> Bytes[16]:
   """
   The FORS secret preimage generation function. Generates the secret 16-byte preimage of the FORS
   leaf at forest-wide index `node_index`. The `ADRS` must be prefilled with the location of the FORS
@@ -1018,7 +1086,9 @@ def fors_sk_gen(sk_seed: bytes, pk_seed: bytes, ADRS: bytearray, node_index: int
   ADRS[18:22] = node_index.to_bytes(4)
   return PRF(pk_seed, sk_seed, ADRS)
 
-def fors_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def fors_node(
+    sk_seed: Bytes[16], node_index: UInt32, node_height: UInt32, pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[16]:
   """
   The FORS internal node computation function. Recursively computes the FORS node at the forest-wide
   `node_index` and `node_height`. The `ADRS` must be prefilled with the location of the FORS keypair
@@ -1057,7 +1127,9 @@ def fors_node(sk_seed: bytes, node_index: int, node_height: int, pk_seed: bytes,
   ADRS[18:22] = node_index.to_bytes(4)
   return H(pk_seed, ADRS, lchild + rchild)
 
-def fors_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def fors_sign(
+    message_digest: Bytes[FORS_DIGEST_SIZE], sk_seed: Bytes[16], pk_seed: Bytes[16], ADRS: bytearray
+) -> Bytes[FORS_SIGNATURE_SIZE]:
   """
   The FORS signing function. Produces a FORS signature on a `message_digest`. The `ADRS` must be
   prefilled with the location of the FORS keypair to ensure the hashes are properly tweaked.
@@ -1082,7 +1154,12 @@ def fors_sign(message_digest: bytes, sk_seed: bytes, pk_seed: bytes, ADRS: bytea
       sig += fors_node(sk_seed, sibling_index, j, pk_seed, ADRS)
   return sig
 
-def fors_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes, ADRS: bytearray) -> bytes:
+def fors_pubkey_from_sig(
+    signature: Bytes[FORS_SIGNATURE_SIZE],
+    message_digest: Bytes[FORS_DIGEST_SIZE],
+    pk_seed: Bytes[16],
+    ADRS: bytearray,
+) -> Bytes[16]:
   """
   The FORS verification function. Recovers a FORS public key from a `signature` on a
   `message_digest`. The `ADRS` must be prefilled with the location of the FORS keypair to ensure
@@ -1131,7 +1208,9 @@ def fors_pubkey_from_sig(signature: bytes, message_digest: bytes, pk_seed: bytes
 
 #  SLH-DSA algorithms
 
-def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: bytes) -> tuple[bytes, int, int]:
+def slh_dsa_digest_message(
+    R: Bytes[16], pk_seed: Bytes[16], sl_root: Bytes[16], message: bytes
+) -> tuple[Bytes[FORS_DIGEST_SIZE], UInt64, UInt32]:
   """
   The SLH-DSA message hashing function. Derives the FORS message digest, bottom-layer XMSS tree
   index, and FORS leaf index from `message` under `H_msg_sl`.
@@ -1143,8 +1222,10 @@ def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: by
     - `message`: a variable-length message.
   - Outputs:
     - a `FORS_DIGEST_SIZE`-byte message digest, ready for use by FORS.
-    - a pseudorandomly selected index of a bottom-layer XMSS tree: an unsigned integer in `[0, 2**SPHX_TREE_INDEX_BITS)`.
-    - a pseudorandomly selected index of a FORS key within an XMSS tree: an unsigned integer in `[0, 2**SPHX_XMSS_HEIGHT)`.
+    - a 64-bit unsigned integer, a pseudorandomly selected index of a bottom-layer XMSS tree,
+      in `[0, 2**SPHX_TREE_INDEX_BITS)`.
+    - a 32-bit unsigned integer, a pseudorandomly selected index of a FORS key within an XMSS
+      tree, in `[0, 2**SPHX_XMSS_HEIGHT)`.
 
   This function is only used in the stateless path, and by both the signer and the verifier.
   """
@@ -1163,7 +1244,15 @@ def slh_dsa_digest_message(R: bytes, pk_seed: bytes, sl_root: bytes, message: by
   return (fors_digest, tree_index, leaf_index)
 
 
-def slh_dsa_sign(message: bytes, ctx: bytes, sk_seed: bytes, sk_prf: bytes, pk_seed: bytes, sl_root: bytes, opt_rand: Optional[bytes]) -> bytes:
+def slh_dsa_sign(
+    message: bytes,
+    ctx: Bytes[:255],
+    sk_seed: Bytes[16],
+    sk_prf: Bytes[16],
+    pk_seed: Bytes[16],
+    sl_root: Bytes[16],
+    opt_rand: Optional[Bytes[16]],
+) -> Bytes[SPHX_SIGNATURE_SIZE]:
   """
   The SLH-DSA signing function. Signs `message` with `sk_seed`, prepending the context `ctx`;
   salts all hashes with `pk_seed`, derives the randomizer from `sk_prf`/`opt_rand`, and binds the
@@ -1207,7 +1296,13 @@ def slh_dsa_sign(message: bytes, ctx: bytes, sk_seed: bytes, sk_prf: bytes, pk_s
 
   return R + fors_signature + hypertree_signature
 
-def slh_dsa_verify(message: bytes, signature: bytes, ctx: bytes, pk_seed: bytes, sl_root: bytes) -> bool:
+def slh_dsa_verify(
+    message: bytes,
+    signature: bytes,
+    ctx: Bytes[:255],
+    pk_seed: Bytes[16],
+    sl_root: Bytes[16],
+) -> bool:
   """
   The SLH-DSA verification function. Recovers the root-tree root from a `signature` on `message`
   (with context `ctx`) and checks it against `sl_root`. Signatures must be produced via
@@ -1215,7 +1310,8 @@ def slh_dsa_verify(message: bytes, signature: bytes, ctx: bytes, pk_seed: bytes,
 
   - Inputs:
     - `message`: a variable-length message.
-    - `signature`: a `SPHX_SIGNATURE_SIZE`-byte signature.
+    - `signature`: a candidate signature, of any length. Any length other than
+      `SPHX_SIGNATURE_SIZE` is not a signature, and is rejected.
     - `ctx`: a context of at most 255 bytes.
     - `pk_seed`: a 16-byte salt.
     - `sl_root`: the 16-byte root hash of the stateless root tree.
@@ -1246,7 +1342,7 @@ def slh_dsa_verify(message: bytes, signature: bytes, ctx: bytes, pk_seed: bytes,
 
 #  SHRINCS algorithms
 
-def shrincs_keygen(seed: bytes, sf_structure: bytes) -> tuple[bytes, bytes]:
+def shrincs_keygen(seed: Bytes[48], sf_structure: Bytes[2]) -> tuple[Bytes[82], Bytes[48]]:
   """
   The SHRINCS key generation function. Computes the secret and public keys from a 48-byte `seed`
   and the stateful tree `sf_structure`.
@@ -1281,7 +1377,9 @@ def shrincs_keygen(seed: bytes, sf_structure: bytes) -> tuple[bytes, bytes]:
   shrincs_pubkey = pk_seed + sl_root + sf_root
   return (shrincs_seckey, shrincs_pubkey)
 
-def shrincs_sf_leaf_select(sf_structure: bytes, state_ctr: Optional[int]) -> Optional[tuple[int, int]]:
+def shrincs_sf_leaf_select(
+    sf_structure: Bytes[2], state_ctr: Optional[UInt64]
+) -> Optional[tuple[UInt64, UInt8]]:
   """
   The SHRINCS stateful-path leaf-selection function. Computes the position `(index, height)` of the
   next WOTS+C leaf for the given `sf_structure` and `state_ctr`.
@@ -1323,7 +1421,14 @@ def shrincs_sf_leaf_select(sf_structure: bytes, state_ctr: Optional[int]) -> Opt
   # - no more signatures left
   return None
 
-def shrincs_sign(message: bytes, ctx: bytes, shrincs_seckey: bytes, state_ctr: Optional[int], opt_rand: Optional[bytes]) -> Optional[bytes]:
+def shrincs_sign(
+    message: Bytes[:2**61 - 384],
+    ctx: Bytes[:255],
+    shrincs_seckey: Bytes[82],
+    state_ctr: Optional[UInt64],
+    opt_rand: Optional[Bytes[16]],
+) -> Optional[Union[Bytes[SPHX_SIGNATURE_SIZE],
+                    Bytes[SHRINCS_SF_SIGNATURE_SIZE_MIN:SHRINCS_SF_SIGNATURE_SIZE_MAX]]]:
   """
   The SHRINCS signing function. Signs `message` and `ctx` with the serialized secret key `shrincs_seckey`:
   uses the stateful FXMSS path when `state_ctr` is valid for the key's tree structure, otherwise
@@ -1389,7 +1494,9 @@ def shrincs_sign(message: bytes, ctx: bytes, shrincs_seckey: bytes, state_ctr: O
 
   return bytes([leaf_height]) + R + leaf_index_bytes + fxmss_signature
 
-def shrincs_verify(message: bytes, signature: bytes, ctx: bytes, shrincs_pubkey: bytes) -> bool:
+def shrincs_verify(
+    message: Bytes[:2**61 - 384], signature: bytes, ctx: Bytes[:255], shrincs_pubkey: Bytes[48]
+) -> bool:
   """
   The SHRINCS verification function. Returns true iff `signature` is a valid stateful or stateless
   SHRINCS signature on `message` under `shrincs_pubkey`. Signatures must be produced via
@@ -1408,7 +1515,10 @@ def shrincs_verify(message: bytes, signature: bytes, ctx: bytes, shrincs_pubkey:
 
   - Inputs:
     - `message`: a message of at most `2**61 - 384` bytes.
-    - `signature`: a candidate SHRINCS signature, of any length.
+    - `signature`: a candidate signature, of any length. The accepted lengths are exactly
+      `SPHX_SIGNATURE_SIZE` for the stateless path and `SHRINCS_SF_SIGNATURE_SIZE_MIN` to
+      `SHRINCS_SF_SIGNATURE_SIZE_MAX` in steps of 16 for the stateful path; any other
+      length is rejected.
     - `ctx`: a context of at most 255 bytes.
     - `shrincs_pubkey`: a 48-byte SHRINCS public key.
   - Output:

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -8,7 +8,7 @@
 # all.
 
 import hashlib
-from typing import Optional
+from typing import Annotated, Optional, Union
 
 #  Helper functions
 
@@ -111,6 +111,49 @@ SF_WOTS_C_PK    = 17
 SF_FXMSS_TREE   = 18
 SF_WOTS_C_PRF   = 21
 SF_WOTS_C_GRIND = 22
+
+
+#  Value types
+
+class LEN:
+  """
+  The metadata behind a `Bytes` or `Array` annotation: an exact `size`, or a
+  range bounded below by `min` and above by `max`.
+  """
+  def __init__(self, size: Optional[int] = None, min: int = 0, max: Optional[int] = None):
+    self.size, self.min, self.max = size, min, max
+
+class UINT:
+  """
+  The metadata behind `UInt8` and its siblings, carrying the width in `bits`.
+  What the annotation requires is stated under Value Types.
+  """
+  def __init__(self, bits: int):
+    self.bits = bits
+
+class Bytes:
+  """
+  Builds the annotation `Bytes[n]` and `Bytes[a:b]` stand for. What they
+  require is stated under Value Types.
+  """
+  def __class_getitem__(cls, size: Union[int, slice]):
+    if isinstance(size, slice):
+      return Annotated[bytes, LEN(min = size.start or 0, max = size.stop)]
+    return Annotated[bytes, LEN(size)]
+
+class Array:
+  """
+  Builds the annotation `Array[T, n]` stands for. What it requires is stated
+  under Value Types.
+  """
+  def __class_getitem__(cls, item: tuple):
+    element, count = item
+    return Annotated[list[element], LEN(count)]
+
+UInt8  = Annotated[int, UINT(8)]
+UInt16 = Annotated[int, UINT(16)]
+UInt32 = Annotated[int, UINT(32)]
+UInt64 = Annotated[int, UINT(64)]
 
 
 #  Primitive cryptographic functions

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -907,19 +907,22 @@ def fxmss_node(
     node_index: UInt64,
     node_height: UInt8,
     pk_seed: Bytes[16],
-    sf_structure: Bytes[2],
+    tree_balanced: bool,
+    tree_depth: UInt8,
     ADRS: bytearray,
 ) -> Bytes[16]:
   """
   The FXMSS internal node computation function. Recursively computes the FXMSS node at the given
-  `node_index` and `node_height` for the tree `sf_structure`.
+  `node_index` and `node_height` for a tree of the given shape and depth.
 
   - Inputs:
     - `sk_seed`: a 16-byte secret.
     - `node_index`: a 64-bit unsigned integer, the index (from the left) of the node in the FXMSS layer.
     - `node_height`: an 8-bit unsigned integer, the height (from the bottom) of the node in the FXMSS tree.
     - `pk_seed`: a 16-byte salt.
-    - `sf_structure`: a 2-byte identifier describing the FXMSS tree structure.
+    - `tree_balanced`: a boolean, true for a balanced (BXMSS) tree and false for an
+      unbalanced (UXMSS) tree.
+    - `tree_depth`: an 8-bit unsigned integer, the depth of the FXMSS tree.
     - `ADRS`: a 22-byte address.
   - Output:
     - a 16-byte FXMSS node hash.
@@ -927,28 +930,31 @@ def fxmss_node(
   This function is only used in the stateful path, and only by the signer.
   """
   node_depth = FXMSS_HEIGHT - node_height
-  tree_shape, tree_depth = sf_structure[0], sf_structure[1]
 
-  is_uxmss_leaf = tree_shape == FXMSS_SHAPE_UNBALANCED and (node_index == 1 or node_depth == tree_depth)
-  is_bxmss_leaf = tree_shape == FXMSS_SHAPE_BALANCED and node_depth == tree_depth
+  is_uxmss_leaf = not tree_balanced and (node_index == 1 or node_depth == tree_depth)
+  is_bxmss_leaf = tree_balanced and node_depth == tree_depth
 
   if is_uxmss_leaf or is_bxmss_leaf:
+    if tree_balanced:
+      tree_shape = FXMSS_SHAPE_BALANCED
+    else:
+      tree_shape = FXMSS_SHAPE_UNBALANCED
     ADRS[0] = node_height
     ADRS[1:9] = node_index.to_bytes(8)
-    ADRS[10:14] = sf_structure + zeros(2)
+    ADRS[10:14] = tree_shape.to_bytes(1) + tree_depth.to_bytes(1) + zeros(2)
     return wots_c_pubkey_gen(sk_seed, pk_seed, ADRS)
 
   # Catch and throw if control would enter an infinite recursive loop.
-  if tree_shape == FXMSS_SHAPE_UNBALANCED:
-    assert node_index == 0
-  elif tree_shape == FXMSS_SHAPE_BALANCED:
+  if tree_balanced:
     assert node_depth < tree_depth
+  else:
+    assert node_index == 0
 
   # Recursively derive the left/right child nodes.
   lchild_index = 2 * node_index
   child_height = node_height - 1
-  lchild = fxmss_node(sk_seed, lchild_index, child_height, pk_seed, sf_structure, ADRS)
-  rchild = fxmss_node(sk_seed, lchild_index + 1, child_height, pk_seed, sf_structure, ADRS)
+  lchild = fxmss_node(sk_seed, lchild_index, child_height, pk_seed, tree_balanced, tree_depth, ADRS)
+  rchild = fxmss_node(sk_seed, lchild_index + 1, child_height, pk_seed, tree_balanced, tree_depth, ADRS)
 
   # Compute and return the parent node.
   ADRS[0] = node_height
@@ -963,7 +969,8 @@ def fxmss_sign(
     leaf_index: UInt64,
     leaf_height: UInt8,
     pk_seed: Bytes[16],
-    sf_structure: Bytes[2],
+    tree_balanced: bool,
+    tree_depth: UInt8,
 ) -> Optional[Bytes[FXMSS_SIGNATURE_SIZE_MIN:FXMSS_SIGNATURE_SIZE_MAX]]:
   """
   The FXMSS signing function. Produces a deterministic WOTS+C signature at the leaf given by
@@ -975,7 +982,9 @@ def fxmss_sign(
     - `leaf_index`: a 64-bit unsigned integer, the index (from the left) of the signing leaf in the FXMSS layer.
     - `leaf_height`: an 8-bit unsigned integer, the height (from the bottom) of the signing leaf in the FXMSS tree.
     - `pk_seed`: a 16-byte salt.
-    - `sf_structure`: a 2-byte identifier describing the FXMSS tree structure.
+    - `tree_balanced`: a boolean, true for a balanced (BXMSS) tree and false for an
+      unbalanced (UXMSS) tree.
+    - `tree_depth`: an 8-bit unsigned integer, the depth of the FXMSS tree.
   - Output:
     - a `2 + 16 * (WOTS_C_CHAIN_COUNT + FXMSS_HEIGHT - leaf_height)`-byte signature, or null.
 
@@ -984,16 +993,20 @@ def fxmss_sign(
   leaf_depth = FXMSS_HEIGHT - leaf_height
 
   # Validate the leaf is positioned correctly for the specified tree structure.
-  tree_shape, tree_depth = sf_structure[0], sf_structure[1]
-  if tree_shape == FXMSS_SHAPE_UNBALANCED:
-    assert leaf_index == 1 or leaf_depth == tree_depth
-  if tree_shape == FXMSS_SHAPE_BALANCED:
+  if tree_balanced:
     assert leaf_depth == tree_depth
+  else:
+    assert leaf_index == 1 or leaf_depth == tree_depth
+
+  if tree_balanced:
+    tree_shape = FXMSS_SHAPE_BALANCED
+  else:
+    tree_shape = FXMSS_SHAPE_UNBALANCED
 
   ADRS = bytearray(22)
   ADRS[0] = leaf_height
   ADRS[1:9] = leaf_index.to_bytes(8)
-  ADRS[10:14] = sf_structure + zeros(2)
+  ADRS[10:14] = tree_shape.to_bytes(1) + tree_depth.to_bytes(1) + zeros(2)
   sig = wots_c_sign(message_digest, sk_seed, pk_seed, ADRS)
   if sig is None:
     return None # practically impossible
@@ -1002,7 +1015,7 @@ def fxmss_sign(
   for j in range(leaf_depth):
     sibling_index = (leaf_index >> j) ^ 1
     sibling_height = leaf_height + j
-    sig += fxmss_node(sk_seed, sibling_index, sibling_height, pk_seed, sf_structure, ADRS)
+    sig += fxmss_node(sk_seed, sibling_index, sibling_height, pk_seed, tree_balanced, tree_depth, ADRS)
 
   return sig
 
@@ -1353,7 +1366,9 @@ def shrincs_keygen(seed: Bytes[48], sf_structure: Bytes[2]) -> tuple[Bytes[82], 
 
   - Inputs:
     - `seed`: a 48-byte random seed. Must be sampled from a CSRNG.
-    - `sf_structure`: a 2-byte identifier describing the shape and depth of the stateful FXMSS tree.
+    - `sf_structure`: a 2-byte identifier describing the FXMSS tree structure: a shape byte, which
+      must be one of the `FXMSS_SHAPE_*` values, followed by a depth byte. See the recommended
+      depths for each shape in [Tree Shapes](#tree-shapes).
   - Outputs:
     - an 82-byte SHRINCS secret key.
     - a 48-byte SHRINCS public key.
@@ -1361,12 +1376,14 @@ def shrincs_keygen(seed: Bytes[48], sf_structure: Bytes[2]) -> tuple[Bytes[82], 
   This function is used only during key generation.
 
   > [!WARNING]
-  > The `sf_structure` argument must come from a trusted source or else be validated.
-  > If an adversary can control `sf_structure` they may cause key-generation to fail, or hang
-  > consuming compute resources by making the implementation generate a very large BXMSS tree.
+  > The `sf_structure` argument must come from a trusted source or else be validated. If an
+  > adversary can control it they may cause key-generation to fail, or hang consuming compute
+  > resources: a balanced tree of depth `sf_structure[1]` costs `2**sf_structure[1]` WOTS+C key
+  > generations, so implementations SHOULD reject a depth they cannot afford to compute.
   """
   assert len(seed) == 48
   assert len(sf_structure) == 2
+  assert sf_structure[0] == FXMSS_SHAPE_UNBALANCED or sf_structure[0] == FXMSS_SHAPE_BALANCED
 
   sk_seed = seed[0:16]
   sk_prf  = seed[16:32]
@@ -1375,7 +1392,8 @@ def shrincs_keygen(seed: Bytes[48], sf_structure: Bytes[2]) -> tuple[Bytes[82], 
   ADRS = bytearray(22)
   ADRS[0] = SPHX_LAYER_COUNT - 1
   sl_root = xmss_node(sk_seed, 0, SPHX_XMSS_HEIGHT, pk_seed, ADRS)
-  sf_root = fxmss_node(sk_seed, 0, FXMSS_HEIGHT, pk_seed, sf_structure, bytearray(22))
+  tree_balanced = sf_structure[0] == FXMSS_SHAPE_BALANCED
+  sf_root = fxmss_node(sk_seed, 0, FXMSS_HEIGHT, pk_seed, tree_balanced, sf_structure[1], bytearray(22))
 
   shrincs_seckey = sk_seed + sk_prf + pk_seed + sl_root + sf_structure + sf_root
   shrincs_pubkey = pk_seed + sl_root + sf_root
@@ -1488,7 +1506,8 @@ def shrincs_sign(
 
   # Bind the stateful signature to the stateless keypair.
   message_digest = H_msg_sf(R, pk_seed, sf_root, ADRS, bound_message)
-  fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, sf_structure)
+  tree_balanced = sf_structure[0] == FXMSS_SHAPE_BALANCED
+  fxmss_signature = fxmss_sign(message_digest, sk_seed, leaf_index, leaf_height, pk_seed, tree_balanced, sf_structure[1])
   if fxmss_signature is None:
     return None # practically impossible
 

--- a/impl/test.py
+++ b/impl/test.py
@@ -3,6 +3,7 @@ from shrincs import shrincs_sign, shrincs_keygen, shrincs_verify
 from shrincs import FXMSS_SHAPE_UNBALANCED, FXMSS_SHAPE_BALANCED, FXMSS_HEIGHT
 
 if __name__ == "__main__":
+  msg = b"foobar!"
   structures = [
     bytes([FXMSS_SHAPE_BALANCED, 4]),
     bytes([FXMSS_SHAPE_UNBALANCED, 16])
@@ -10,7 +11,6 @@ if __name__ == "__main__":
   for (i, sf_structure) in enumerate(structures):
     sk, pk = shrincs_keygen(randbytes(48), sf_structure)
 
-    msg = b"foobar!"
     for j in range(16):
       sig = shrincs_sign(msg, b"", sk, j, None)
       assert shrincs_verify(msg, sig, b"", pk)
@@ -20,3 +20,13 @@ if __name__ == "__main__":
       sig = shrincs_sign(msg, b"", sk, None, None)
       assert shrincs_verify(msg, sig, b"", pk)
       print(f'verified stateless signature')
+
+  # Trees deep enough to climb past 64 levels, which nothing else covers. Depth
+  # 255 also gives the longest FXMSS signature, and counter 0 the shortest.
+  for deep_depth, counters in ((70, (62, 63, 64, 65)), (FXMSS_HEIGHT, (0, 253, 254, 255))):
+    deep_structure = bytes([FXMSS_SHAPE_UNBALANCED, deep_depth])
+    sk, pk = shrincs_keygen(randbytes(48), deep_structure)
+    for j in counters:
+      sig = shrincs_sign(msg, b"", sk, j, None)
+      assert shrincs_verify(msg, sig, b"", pk)
+    print(f'verified deep stateful signatures for structure {deep_structure.hex()}')

--- a/pydoc_insert.py
+++ b/pydoc_insert.py
@@ -2,6 +2,7 @@
 
 import re
 import ast
+import inspect
 from argparse import ArgumentParser
 import shutil
 
@@ -16,6 +17,7 @@ from impl import shrincs, meta
 with open('impl/shrincs.py') as fh:
   shrincs_source = fh.read()
 
+shrincs_source_lines = shrincs_source.splitlines(keepends = True)
 shrincs_code_lines = [line.rstrip() for line in shrincs_source.split('\n')]
 shrincs_ast = ast.parse(shrincs_source)
 
@@ -24,6 +26,19 @@ definitions = {}
 for node in shrincs_ast.body:
   if isinstance(node, ast.FunctionDef):
     definitions[node.name] = node
+
+#  The first source line of a definition. A decorator is not part of the
+#  node's own extent, and the `@` may sit on a line above the expression it
+#  applies to.
+def start_line(node: ast.stmt) -> int:
+  decorators = getattr(node, 'decorator_list', [])
+  if not decorators:
+    return node.lineno - 1
+  line = min(decorator.lineno for decorator in decorators) - 1
+  while not shrincs_code_lines[line].lstrip().startswith('@'):
+    line -= 1
+  return line
+
 
 class SpecFunction:
   """
@@ -36,10 +51,20 @@ class SpecFunction:
 
     #  The signature, then the body with any docstring elided.
     body_start = node.body[0]
+    starts_at = start_line(node)
     body_from = body_start.end_lineno if self.docstring is not None else body_start.lineno - 1
 
-    signature = shrincs_code_lines[node.lineno - 1 : body_start.lineno - 1]
-    self.codestring = '\n'.join(signature + shrincs_code_lines[body_from : node.end_lineno])
+    #  `inspect.getblock` finds where the definition really ends, including
+    #  any trailing comment, which is not a node and so has no `end_lineno`.
+    #  It also keeps a comment which introduces whatever follows, so stop at
+    #  the blank line which separates one from the body it would follow.
+    block_end = starts_at + len(inspect.getblock(shrincs_source_lines[starts_at:]))
+    ends_at = node.end_lineno
+    while ends_at < block_end and shrincs_code_lines[ends_at].strip():
+      ends_at += 1
+
+    signature = shrincs_code_lines[starts_at : body_start.lineno - 1]
+    self.codestring = '\n'.join(signature + shrincs_code_lines[body_from : ends_at])
 
 
 regex_doc_start = r"^<!-- DOC START (\w+) -->$"

--- a/pydoc_insert.py
+++ b/pydoc_insert.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import re
-import inspect
+import ast
 from argparse import ArgumentParser
 import shutil
 
@@ -14,23 +14,32 @@ into SHRINCS.md. We parse markdown comments as doc/const insert directives.
 from impl import shrincs, meta
 
 with open('impl/shrincs.py') as fh:
-  shrincs_code_lines = [line.rstrip() for line in fh]
+  shrincs_source = fh.read()
+
+shrincs_code_lines = [line.rstrip() for line in shrincs_source.split('\n')]
+shrincs_ast = ast.parse(shrincs_source)
+
+#  Top-level function definitions, by name.
+definitions = {}
+for node in shrincs_ast.body:
+  if isinstance(node, ast.FunctionDef):
+    definitions[node.name] = node
 
 class SpecFunction:
   """
   Data structure to document a SHRINCS specification function.
   """
-  def __init__(self, function_name: str):
-    fn = shrincs.__getattribute__(function_name)
-    positions = list(fn.__code__.co_positions())
-    def_line = positions[0][0] - 1
-    code_start_line = positions[1][0] - 1
-    code_end_line = positions[-1][0]
-    if fn.__doc__ is not None:
-      self.docstring = inspect.cleandoc(fn.__doc__)
-    else:
-      self.docstring = None
-    self.codestring = '\n'.join([shrincs_code_lines[def_line], *shrincs_code_lines[code_start_line : code_end_line]])
+  def __init__(self, name: str):
+    node = definitions[name]
+
+    self.docstring = ast.get_docstring(node)
+
+    #  The signature, then the body with any docstring elided.
+    body_start = node.body[0]
+    body_from = body_start.end_lineno if self.docstring is not None else body_start.lineno - 1
+
+    signature = shrincs_code_lines[node.lineno - 1 : body_start.lineno - 1]
+    self.codestring = '\n'.join(signature + shrincs_code_lines[body_from : node.end_lineno])
 
 
 regex_doc_start = r"^<!-- DOC START (\w+) -->$"
@@ -53,23 +62,23 @@ if __name__ == "__main__":
       doc_start_match = re.match(regex_doc_start, markdown_lines[i])
       const_start_match = re.search(regex_const, markdown_lines[i])
       if doc_start_match:
-        function_name = doc_start_match.group(1)
+        definition_name = doc_start_match.group(1)
         out.write(markdown_lines[i])
 
-        spec_fn = SpecFunction(function_name)
-        if spec_fn.docstring is not None:
-          out.write(spec_fn.docstring + '\n\n')
+        spec_function = SpecFunction(definition_name)
+        if spec_function.docstring is not None:
+          out.write(spec_function.docstring + '\n\n')
         out.write("```py" + '\n')
-        out.write(spec_fn.codestring + '\n')
+        out.write(spec_function.codestring + '\n')
         out.write("```" + '\n')
 
         while True:
-          if re.match(r"^<!-- DOC END %s -->$" % function_name, markdown_lines[i]):
+          if re.match(r"^<!-- DOC END %s -->$" % definition_name, markdown_lines[i]):
             out.write(markdown_lines[i])
             break
           i += 1
           if i >= len(markdown_lines):
-            raise RuntimeError("failed to find closing <!-- DOC END %s --> comment" % function_name)
+            raise RuntimeError("failed to find closing <!-- DOC END %s --> comment" % definition_name)
 
       elif const_start_match:
         replacements = []


### PR DESCRIPTION
Fixes an implementation-divergence bug. `fxmss_pubkey_from_sig` computed `leaf_index >> (k + 1)` with a shift distance reaching 255, and that path is reachable from an honest signature (unbalanced tree, depth 255). At that distance a shift is undefined or width-modulo depending on the language, so a faithful fixed-width port rejects signatures this specification accepts.

`ancestor_of` climbs one level at a time and forms no power; `sibling_of` names the odd-or-even choice and carries its own non-underflow argument. The second commit retires the last of `<<`, `>>` and `&`, and defines `%`, `**` and `xor` under Utilities.

Signature bytes unchanged. The suite gains depth-70 and depth-255 trees at counters straddling 64 levels, which nothing previously covered.

Stacked on PR #51 