### PR TITLE
add more padding to H_grind

### DIFF
--- a/SHRINCS.md
+++ b/SHRINCS.md
@@ -773,11 +773,11 @@ This function is only used in the stateful path, and by both the signer and the 
 ```py
 def H_grind(pk_seed: bytes, ADRS: bytearray, digest: bytes, counter: int) -> bytes:
   assert counter <= 0xFFFF
-  return sha256(pk_seed + zeros(48) + ADRS[:10] + digest + zeros(4) + counter.to_bytes(2))[:16]
+  return sha256(pk_seed + zeros(48) + ADRS[:10] + digest + zeros(8) + counter.to_bytes(2))[:16]
 ```
 <!-- DOC END H_grind -->
 
-The extra 4 bytes of padding before the counter ensures the counter lines up with the SHA256 message schedule boundaries.
+The extra 8 bytes of padding before the counter ensures the counter lines up with the SHA256 message schedule word boundaries.
 
 Notice we only use the first 10 bytes of `ADRS`.
 This ensures the entire hash input fits inside a single SHA256 compression call, given the cached `pk_seed` input.

--- a/impl/shrincs.py
+++ b/impl/shrincs.py
@@ -240,7 +240,7 @@ def H_grind(pk_seed: bytes, ADRS: bytearray, digest: bytes, counter: int) -> byt
   This function is only used in the stateful path, and by both the signer and the verifier.
   """
   assert counter <= 0xFFFF
-  return sha256(pk_seed + zeros(48) + ADRS[:10] + digest + zeros(4) + counter.to_bytes(2))[:16]
+  return sha256(pk_seed + zeros(48) + ADRS[:10] + digest + zeros(8) + counter.to_bytes(2))[:16]
 
 def PRF(pk_seed: bytes, sk_seed: bytes, ADRS: bytearray) -> bytes:
   """


### PR DESCRIPTION
We currently inject 4 bytes of padding to `H_grind`, leading to the following SHA256 message schedule layout:

```
      0           1                  2                    3            4                5               6               7               8               9                    10                   11              12            13            14               15
| ADRS[0:4] | ADRS[4:8] | ADRS[8:10] + digest[0:2] | digest[2:6] | digest[6:10] | digest[10:14] | digest[14:18] | digest[18:22] | digest[22:26] | digest[26:30] | digest[30:32] + 0x0000 | 0x0000 + counter | 0x80000000 | 0x00000000 | bit_length[0:4] | bit_length[4:8] |
```

This commit adds 4 extra padding bytes to move the grinding counter to isolate it at the very last non-padding word, `W[12]`.

New layout:
```
      0           1                  2                    3            4                5               6               7               8               9                    10               11              12                13            14               15
| ADRS[0:4] | ADRS[4:8] | ADRS[8:10] + digest[0:2] | digest[2:6] | digest[6:10] | digest[10:14] | digest[14:18] | digest[18:22] | digest[22:26] | digest[26:30] | digest[30:32] + 0x0000 | 0x00000000 | 0x0000 + counter  | 0x80000000 | bit_length[0:4] | bit_length[4:8] |
```

This enables one more round to be cached, and is a little less arbitrary than our previous design.